### PR TITLE
Feature/undo split gene

### DIFF
--- a/resources/schema/definitions.edn
+++ b/resources/schema/definitions.edn
@@ -38,6 +38,9 @@
  #:db{:ident :gene.status/dead}
  #:db{:ident :gene.status/suppressed}
  #:db{:ident :gene.status/live}
+ #:db{:ident :provenance/compensates
+      :valueType :db.type/ref
+      :cardinality :db.cardinality/one}
  #:db{:ident :provenance/why,
       :valueType :db.type/string,
       :cardinality :db.cardinality/one}

--- a/resources/schema/tx-fns.edn
+++ b/resources/schema/tx-fns.edn
@@ -17,10 +17,12 @@
   {:params [db ident]
    :lang "clojure"
    :code
-   "(some->> (d/datoms db :avet ident)
-             (sort-by (comp d/tx->t :tx))
-             (last)
-             (:v))"}}
+   "(d/q '[:find (max ?gid) .
+           :in $ ?ident
+           :where
+           [?e ?ident ?gid]]
+          (d/history db)
+          ident))"}}
 
  {:db/ident :wormbase.tx-fns/latest-id-number
   :db/doc
@@ -35,7 +37,18 @@
                   (re-seq #\"0*(\\d+)\")
                   (flatten)
                   (last)
-                  (read-string)) 0))"}}
+                  (read-string))
+          0))"}}
+
+ {:db/ident :wormbase.tx-fns/next-identifier
+  :db/doc "Get the next sequential identifier for a given ident."
+  :db/fn #db/fn
+  {:params [db ident template]
+   :lang "clojure"
+   :code
+   "(let [invoke (partial d/invoke db)
+          last-id (invoke :wormbase.tx-fns/latest-id-number db ident)]
+      (->> last-id inc (format template)))"}}
 
  {:db/ident :wormbase.tx-fns/gene-dbid-ref
   :db/doc "Return an identifier sutiable for inter-transaction referencing for new gene."
@@ -57,22 +70,20 @@
    :params [db entity-type data spec]
    :code
    "(if (s/valid? spec data)
-     (let [ident (keyword entity-type \"id\")
+     (let [invoke (partial d/invoke db)
+           ident (keyword entity-type \"id\")
            template (-> (d/entity db [:template/describes ident])
                         :template/format)
-           last-id (d/invoke db
-                             :wormbase.tx-fns/latest-id-number
-                             db
-                             ident)
-           new-gene-ref (d/invoke db
-                                  :wormbase.tx-fns/gene-dbid-ref
-                                  db
-                                  data)
+           ;; last-id (invoke :wormbase.tx-fns/latest-id-number db ident)
+           new-gene-ref (invoke :wormbase.tx-fns/gene-dbid-ref db data)
            identify (fn [rec]
-                      (let [next-identifier (format template 
-                                                    (+ last-id 1))
+                      (let [next-id (invoke
+                                     :wormbase.tx-fns/next-identifier
+                                     db
+                                     ident
+                                     template)
                             species-lur (-> rec :gene/species vec first)]
-                        (-> (assoc rec ident next-identifier)
+                        (-> (assoc rec ident next-id)
                             (assoc :gene/species species-lur)
                             (assoc :gene/status :gene.status/live))))
            new (-> data

--- a/src/org/wormbase/specs/gene.clj
+++ b/src/org/wormbase/specs/gene.clj
@@ -173,3 +173,12 @@
 
 (s/def ::split (s/keys :req [:gene/biotype]
                        :req-un [::product]))
+
+(s/def ::split-response (s/keys :req-un [::updated ::created]))
+
+(s/def ::live :gene/id)
+
+(s/def ::dead :gene/id)
+
+(s/def ::split-undone (s/keys :req-un [::live ::dead]))
+

--- a/test/integration/test_split_gene.clj
+++ b/test/integration/test_split_gene.clj
@@ -228,8 +228,7 @@
                        :provenance/why
                        "a gene that has been split for testing undo"
                        :provenance/how :agent/script}]]
-          ;conn (db-testing/fixture-conn)
-          conn owdb/conn]
+          conn (db-testing/fixture-conn)]
       (with-redefs [owdb/connection (fn get-fixture-conn [] conn)
                     owdb/db (fn get-db [_] (d/db conn))]
         (doseq [init-tx init-txes]
@@ -260,7 +259,6 @@
                 [from-g into-g] (map #(d/entity db [:gene/id %])
                                      [split-from split-into])]
             (t/is (= (:gene/status from-g) :gene.status/live))
-            ;; TODO: never retract :gene/id and :gene/status and enable this check
             (t/is (= (:gene/status into-g) :gene.status/dead)
                   (str "Into gene:"
                        (d/q '[:find ?e ?aname ?v ?added

--- a/test/org/wormbase/test_dbfns.clj
+++ b/test/org/wormbase/test_dbfns.clj
@@ -197,7 +197,7 @@
   (let [sn (-> sample
                :gene/species
                :species/id
-               tu/gen-valid-seq-name-for-species)]
+               tu/gen-valid-seq-name)]
     (if (= sn (:gene/sequence-name sample))
       (recur sample)
       sn)))

--- a/test/org/wormbase/test_utils.clj
+++ b/test/org/wormbase/test_utils.clj
@@ -18,7 +18,9 @@
    [peridot.core :as p]
    [spec-tools.core :as stc]
    [datomic.api :as d])
-  (:import (java.io InputStream)))
+  (:import
+   (clojure.lang ExceptionInfo)
+   (java.io InputStream)))
 
 ;; TODO: Unify way of creating muuntaja formats "instance"?
 ;;       (Duplication as per o.w.n/service.clj - which does it correctly!)
@@ -49,9 +51,9 @@
         body (if (instance? String body)
                (try
                  (muuntaja/decode mformats "application/edn" body)
-                 (catch clojure.lang.ExceptionInfo jpe
-                   (print-decode-err jpe body)
-                   (throw jpe)))
+                 (catch ExceptionInfo exc
+                   (print-decode-err exc body)
+                   (throw exc)))
                body)]
     body))
 
@@ -120,6 +122,16 @@
                        :params params))]
     [status (parse-body body)]))
 
+(defn delete [app uri content-type headers]
+  (let [request (-> (p/session app)
+                    (p/request uri
+                               :request-method :delete
+                               :headers (or headers {})
+                               :content-type (or content-type
+                                                 "application/edn")))
+        {{:keys [status body response-headers]} :response} request]
+    [status (read-body body) response-headers]))
+
 (defn raw-put-or-post* [app uri method data content-type headers]
   (let [request (-> (p/session app)
                     (p/request uri
@@ -175,7 +187,7 @@
                           (stc/deserialize suspec)
                           body)))))
 
-(defn- map->set [m]
+(defn map->set [m]
   (assert (map? m))
   (some->> (apply vector m)
            (flatten)

--- a/test/org/wormbase/test_utils.clj
+++ b/test/org/wormbase/test_utils.clj
@@ -258,7 +258,7 @@
                     :provenance/why
                     :provenance/how])))
 
-(defn gen-valid-seq-name-for-species [species]
+(defn gen-valid-seq-name [species]
   (-> species
       owsg/name-patterns
       :gene/sequence-name
@@ -280,7 +280,7 @@
                     (let [sn (-> m
                                  :gene/species
                                  :species/id
-                                 gen-valid-seq-name-for-species)]
+                                 gen-valid-seq-name)]
                       (assoc m :gene/sequence-name sn)))))
         gene-ids (map :gene/id (flatten gene-refs))]
     (if-let [dup-seq-names? (->> data-samples


### PR DESCRIPTION
This implements undo for a "gene split" operation.
Details are in the commit message for f459a65

Implementation of `org.wormbase.db/invert-tx` is a slightly modified version of 
the function presented by Tim Ewald at the end of his [slldes][1] on using reified transactions,
the modified version allowing for custom provenence data and customisation of which attributes get retracted via a `fact-mapper` function.

[1]: https://docs.datomic.com/on-prem/videos.html#reified-transactions