### PR TITLE
Feature/undo merge genes

### DIFF
--- a/resources/schema/definitions.edn
+++ b/resources/schema/definitions.edn
@@ -38,6 +38,9 @@
  #:db{:ident :gene.status/dead}
  #:db{:ident :gene.status/suppressed}
  #:db{:ident :gene.status/live}
+ #:db{:ident :provenance/compensates
+      :valueType :db.type/ref
+      :cardinality :db.cardinality/one}
  #:db{:ident :provenance/why,
       :valueType :db.type/string,
       :cardinality :db.cardinality/one}

--- a/resources/schema/tx-fns.edn
+++ b/resources/schema/tx-fns.edn
@@ -166,23 +166,23 @@
                        :record data})))"}}
 
  {:db/ident :wormbase.tx-fns/merge-genes
-  :db/doc "Merge gene `src` into gene `target`."
+  :db/doc "Merge gene `src` into gene `into`."
   :db/fn #db/fn
   {:lang "clojure"
    :requires [[clojure.spec.alpha :as s]]
-   :params [db src-id target-id id-spec target-biotype]
+   :params [db from-id into-id id-spec into-biotype]
    :code
-   "(let [participants [[id-spec src-id] [id-spec target-id]]
+   "(let [participants [[id-spec from-id] [id-spec into-id]]
           valids (zipmap participants
                          (map (partial s/valid? id-spec) participants))]
-      (when (= src-id target-id)
-        (throw (ex-info \"Source and target ids cannot be the same!\"
-                        {:src-id src-id
-                         :target-id target-id
+      (when (= from-id into-id)
+        (throw (ex-info \"Source and into ids cannot be the same!\"
+                        {:from-id from-id
+                         :into-id into-id
                          :type ::validation-error})))
-      (when-not (s/valid? :gene/biotype target-biotype)
+      (when-not (s/valid? :gene/biotype into-biotype)
          (throw (ex-info \"Invalid biotype\"
-                          {:problems (s/explain-data :gene/biotype target-biotype)
+                          {:problems (s/explain-data :gene/biotype into-biotype)
                            :type ::validation-error})))
       (when (some nil? (vals valids))
         (let [invalids (some->> valids
@@ -194,50 +194,50 @@
                                            invalids)
                             :type ::validation-error
                             :invalid-entities invalids}))))
-       (let [[src target] (map #(d/entity db %) participants)]
+       (let [[from into] (map #(d/entity db %) participants)]
          (when-let [deads (filter #(= (:gene/status %) :gene.status/dead)
-                                  [src target])]
+                                  [from into])]
            (when-not (empty? deads)
              (throw (ex-info \"Both merge participants must be live\"
                              {:type :org.wormbase.db/conflict
                               :dead-genes (map :gene/id deads)}))))
-         (when (some nil? [src target])
+         (when (some nil? [from into])
            (throw (ex-info \"Merge participant does not exist!\"
                             {:missing (remove (comp not nil?)
-                                              (map :gene/id [src target]))
+                                              (map :gene/id [from into]))
                              :type :org.wormbase.db/missing
                              :participants participants})))
-         (when (reduce not= (map (comp :species/id :gene/species) [src target]))
+         (when (reduce not= (map (comp :species/id :gene/species) [from into]))
            (throw (ex-info \"Refusing to merge: genes have differing species\"
-                           {:src {id-spec src-id
-                                  :species/id (:gene/species src)}
-                            :target {id-spec target-id
-                                     :species/id (:gene/species target)}
+                           {:from {id-spec from-id
+                                  :species/id (:gene/species from)}
+                            :into {id-spec into-id
+                                     :species/id (:gene/species into)}
                             :type :org.wormbase.db/conflict})))
-         (when (:gene/cgc-name src)
+         (when (:gene/cgc-name from)
            (throw (ex-info (str \"Gene to be killed has a CGC name, \"
                                 \"refusing to merge\")
-                            {:src-id src-id
-                             :src-cgc-name (:gene/cgc-name src)
+                            {:from-id from-id
+                             :from-cgc-name (:gene/cgc-name from)
                              :type :org.wormbase.db/conflict})))
           (let [entid (partial d/entid db)
-                src-seq-name (:gene/sequence-name src)
+                from-seq-name (:gene/sequence-name from)
                 none? #(every? nil? %)
-                uncloned-target? (none? ((juxt :gene/biotype :gene/sequence-name)
-                                         target))
-                [sid tid] (map :db/id [src target])
+                uncloned-into? (none? ((juxt :gene/biotype :gene/sequence-name)
+                                         into))
+                [sid tid] (map :db/id [from into])
                 txes [[:db.fn/cas sid :gene/status
-                                      (entid (:gene/status src))
+                                      (entid (:gene/status from))
                                       (entid :gene.status/dead)]
                       [:db.fn/cas tid :gene/biotype
-                                      (entid (:gene/biotype target))
-                                      (entid target-biotype)]]
-                tx-data (if uncloned-target?
+                                      (entid (:gene/biotype into))
+                                      (entid into-biotype)]]
+                tx-data (if uncloned-into?
                           (-> txes
                               (conj
-                               [:db/retract sid :gene/sequence-name src-seq-name])
+                               [:db/retract sid :gene/sequence-name from-seq-name])
                               (conj
-                               [:db.fn/cas tid :gene/sequence-name nil src-seq-name]))
+                               [:db.fn/cas tid :gene/sequence-name nil from-seq-name]))
                           txes)]
              tx-data)))"}}
  

--- a/resources/schema/tx-fns.edn
+++ b/resources/schema/tx-fns.edn
@@ -17,10 +17,12 @@
   {:params [db ident]
    :lang "clojure"
    :code
-   "(some->> (d/datoms db :avet ident)
-             (sort-by (comp d/tx->t :tx))
-             (last)
-             (:v))"}}
+   "(d/q '[:find (max ?gid) .
+           :in $ ?ident
+           :where
+           [?e ?ident ?gid]]
+          (d/history db)
+          ident))"}}
 
  {:db/ident :wormbase.tx-fns/latest-id-number
   :db/doc
@@ -35,7 +37,18 @@
                   (re-seq #\"0*(\\d+)\")
                   (flatten)
                   (last)
-                  (read-string)) 0))"}}
+                  (read-string))
+          0))"}}
+
+ {:db/ident :wormbase.tx-fns/next-identifier
+  :db/doc "Get the next sequential identifier for a given ident."
+  :db/fn #db/fn
+  {:params [db ident template]
+   :lang "clojure"
+   :code
+   "(let [invoke (partial d/invoke db)
+          last-id (invoke :wormbase.tx-fns/latest-id-number db ident)]
+      (->> last-id inc (format template)))"}}
 
  {:db/ident :wormbase.tx-fns/gene-dbid-ref
   :db/doc "Return an identifier sutiable for inter-transaction referencing for new gene."
@@ -57,22 +70,20 @@
    :params [db entity-type data spec]
    :code
    "(if (s/valid? spec data)
-     (let [ident (keyword entity-type \"id\")
+     (let [invoke (partial d/invoke db)
+           ident (keyword entity-type \"id\")
            template (-> (d/entity db [:template/describes ident])
                         :template/format)
-           last-id (d/invoke db
-                             :wormbase.tx-fns/latest-id-number
-                             db
-                             ident)
-           new-gene-ref (d/invoke db
-                                  :wormbase.tx-fns/gene-dbid-ref
-                                  db
-                                  data)
+           ;; last-id (invoke :wormbase.tx-fns/latest-id-number db ident)
+           new-gene-ref (invoke :wormbase.tx-fns/gene-dbid-ref db data)
            identify (fn [rec]
-                      (let [next-identifier (format template 
-                                                    (+ last-id 1))
+                      (let [next-id (invoke
+                                     :wormbase.tx-fns/next-identifier
+                                     db
+                                     ident
+                                     template)
                             species-lur (-> rec :gene/species vec first)]
-                        (-> (assoc rec ident next-identifier)
+                        (-> (assoc rec ident next-id)
                             (assoc :gene/species species-lur)
                             (assoc :gene/status :gene.status/live))))
            new (-> data

--- a/src/org/wormbase/db.clj
+++ b/src/org/wormbase/db.clj
@@ -86,7 +86,7 @@
         datoms)
        (throw (ex-info "No tx to invert"
                        {:tx tx
-                        :type ::conflict
+                        :type ::invert-tx-problem
                         :range (d/tx-range log t (inc t))})))))
     ([log tx provenance]
      (invert-tx log tx provenance (constantly nil))))

--- a/src/org/wormbase/db/schema.clj
+++ b/src/org/wormbase/db/schema.clj
@@ -55,6 +55,7 @@
         (PushbackReader.)
         (edn-read))))
 
+;; TODO: store seed data in resources/schema as EDN.
 (def seed-data {:agents
                 [{:agent/id :agent/web-form}
                  {:agent/id :agent/script}]

--- a/src/org/wormbase/names/auth.clj
+++ b/src/org/wormbase/names/auth.clj
@@ -18,15 +18,14 @@
    [ring.util.codec :as ruc]
    [ring.util.http-response :as http-response]))
 
-;; TODO:
-;; dispatch to a different (buddy)backend credentials store
-;; depending on the request's user-agent
-;;; If requset is via a web browser,
-;;; then we want to get credentials from the OS's environ/beanstalk env vars
-;;;
-;;; If request is via a Perl/Python script,
-;;; then we want to retrieve the credentials from the configured file on disk
-;;; (or else make people set env vars every time they run their scripts?)
+;; TODO: dispatch to a different (buddy)backend credentials store
+;;       depending on the request's user-agent
+;;       If requset is via a web browser,
+;;       then we want to get credentials from the OS's environ/beanstalk env vars
+;;
+;;       If request is via a Perl/Python script,
+;;       then we want to retrieve the credentials from the configured file on disk
+;;       (or else make people set env vars every time they run their scripts?)
 
 ;;; ENSURE NOT TO LEAK INFO (e.g CLIENT_SECRET, via any logging)
 

--- a/src/org/wormbase/names/errhandlers.clj
+++ b/src/org/wormbase/names/errhandlers.clj
@@ -68,7 +68,6 @@
 (defn handle-unexpected-error
   ([^Exception exc data request]
    ;; TODO: logging - ensure exceptions appear in the log/stdout.
-   ;; TODO: remove constant comparison thing below (or true x)
    (if-not (empty? ((juxt :test :dev) environ/env))
      (handle-unexpected-error exc)
      (http-response/internal-server-error data)))

--- a/src/org/wormbase/specs/auth.clj
+++ b/src/org/wormbase/specs/auth.clj
@@ -1,8 +1,7 @@
 (ns org.wormbase.specs.auth
   (:require
    [clojure.spec.alpha :as s]
-   [clojure.string :as str]
-   [spec-tools.spec :as sts]))
+   [clojure.string :as str]))
 
 ;;; TODO: perhaps use urly instead of re-inventing wheels?
 ;;;   https://github.com/michaelklishin/urly
@@ -10,19 +9,19 @@
 
 (def https? #(str/starts-with? % "https://"))
 
-(def absolute-uri (s/and sts/string? https?))
+(def absolute-uri (s/and string? https?))
 
-(def relative-uri (or absolute-uri (s/and sts/string? #(str/starts-with? % "/"))))
+(def relative-uri (or absolute-uri (s/and string? #(str/starts-with? % "/"))))
 
 (s/def ::authorize-uri absolute-uri)
 
-(s/def ::access-token-uri (s/and sts/string? https?))
+(s/def ::access-token-uri (s/and string? https?))
 
 (s/def ::redirect-uri relative-uri)
 
-(s/def ::client-secret (s/and sts/string? not-empty))
+(s/def ::client-secret (s/and string? not-empty))
 
-(s/def ::client-id (s/spec (s/and sts/string? not-empty)))
+(s/def ::client-id (s/spec (s/and string? not-empty)))
 
 (s/def ::auth-profile (s/keys :req-un [::client-secret ::client-id]))
 
@@ -35,7 +34,7 @@
                                         ::client-id
                                         ::client-secret]))
 
-(s/def ::authorization (s/and sts/string? #(str/starts-with? "Bearer " %)))
+(s/def ::authorization (s/and string? #(str/starts-with? "Bearer " %)))
 
 (s/def ::bearer-authentication ::authorization)
 

--- a/src/org/wormbase/specs/gene.clj
+++ b/src/org/wormbase/specs/gene.clj
@@ -180,5 +180,5 @@
 
 (s/def ::dead :gene/id)
 
-(s/def ::split-undone (s/keys :req-un [::live ::dead]))
+(s/def ::undone (s/keys :req-un [::live ::dead]))
 

--- a/src/org/wormbase/specs/gene.clj
+++ b/src/org/wormbase/specs/gene.clj
@@ -173,3 +173,12 @@
 
 (s/def ::split (s/keys :req [:gene/biotype]
                        :req-un [::product]))
+
+(s/def ::split-response (s/keys :req-un [::updated ::created]))
+
+(s/def ::live :gene/id)
+
+(s/def ::dead :gene/id)
+
+(s/def ::split-undone (s/keys :req-un [::live ::dead]))
+

--- a/test/integration/test_merge_genes.clj
+++ b/test/integration/test_merge_genes.clj
@@ -1,16 +1,18 @@
 (ns integration.test-merge-genes
   (:require
    [clojure.test :as t]
+   [datomic.api :as d]
+   [java-time :as jt]
+   [org.wormbase.db :as owdb]
    [org.wormbase.fake-auth :as fake-auth]
    [org.wormbase.db-testing :as db-testing]
    [org.wormbase.names.service :as service]
+   [org.wormbase.names.util :as ownu]
    [org.wormbase.test-utils :refer [raw-put-or-post*
                                     parse-body
                                     status-is?
                                     body-contains?]]
-   [org.wormbase.test-utils :as tu]
-   [datomic.api :as d]
-   [java-time :as jt])
+   [org.wormbase.test-utils :as tu])
   (:import (java.util Date)))
 
 (t/use-fixtures :each db-testing/db-lifecycle)
@@ -43,40 +45,52 @@
                     :provenance/why])))
 
 (defn merge-genes
-  [payload src-id target-id
+  [payload from-id into-id
    & {:keys [current-user]
       :or {current-user "tester@wormbase.org"}}]
   (binding [fake-auth/*current-user* current-user]
     (let [data (pr-str payload)
           current-user-token (get fake-auth/tokens current-user)
+          uri (str "/gene/" into-id "/merge-from/" from-id)
           [status body]
           (raw-put-or-post*
            service/app
-           (str "/gene/" src-id "/merge/" target-id)
+           uri
            :post
            data
            "application/edn"
            {"authorization" (str "Bearer " current-user-token)})]
       [status (parse-body body)])))
 
+(defn undo-merge-genes
+  [from-id into-id & {:keys [current-user]
+                      :or {current-user "tester@wormbase.org"}}]
+  (binding [fake-auth/*current-user* current-user]
+    (let [current-user-token (get fake-auth/tokens current-user)]
+      (tu/delete service/app
+                 (str "/gene/" into-id "/merge-from/" from-id)
+                 "application/edn"
+                 {"authorization" (str "Bearer " current-user-token)}))))
+
+
 (t/deftest must-meet-spec
   (t/testing "Request to merge genes must meet spec."
-    (let [response (merge-genes {} "WBGene00000001" "WBGene00000002")
+    (let [response (merge-genes {} "WBGene00000002" "WBGene00000001")
           [status body] response]
       (status-is? status 400 body)
       (t/is (contains? (parse-body body) :problems) (pr-str body))))
   (t/testing "Target biotype always required when merging genes."
-    (let [[status body] (merge-genes {} "WB1" "WB2")]
+    (let [[status body] (merge-genes {} "WB2" "WB1")]
       (status-is? status 400 (format "Body: " body)))))
 
 (t/deftest response-codes
   (t/testing "404 for gene missing"
     (let [[status body] (merge-genes {:gene/biotype :biotype/transposon}
-                                     "WB1"
-                                     "WB2")]
+                                     "WB2"
+                                     "WB1")]
       (t/is (= status 404) (pr-str body))))
   (t/testing "409 for conflicting state"
-    (let [[[src-id target-id] _ data-samples] (tu/gene-samples 2)
+    (let [[[from-id into-id] _ data-samples] (tu/gene-samples 2)
           [sample-1 sample-2] [(-> data-samples
                                    first
                                    (assoc :gene/status :gene.status/dead)
@@ -93,47 +107,100 @@
           (let [db (d/db conn)
                 entid (partial d/entid db)
                 entity (partial d/entity db)
-                lur [:gene/id target-id]]
+                lur [:gene/id into-id]]
             @(d/transact-async conn [[:db.fn/cas
                                       lur
                                       :gene/status
                                       (-> lur entity :gene/status entid)
                                       (entid :gene.status/dead)]]))
           (let [[status body] (merge-genes {:gene/biotype :biotype/cds}
-                                           src-id
-                                           target-id)]
+                                           from-id
+                                           into-id)]
             (t/is (= status 409) (pr-str body)))))))
   (t/testing "400 for validation errors"
     (let [[status body] (merge-genes {:gene/biotype :biotype/godzilla}
-                                     "WBGene00000001"
-                                     "WBGene00000002")]
+                                     "WBGene00000002"
+                                     "WBGene00000001")]
       (t/is (= status 400) (pr-str body))
       (t/is (re-seq #"Invalid.*biotype" (:message body))))))
 
 (t/deftest provenance-recorded
   (t/testing "Provenence for successful merge is recorded."
-    (let [[gene-ids _ [gene-1 gene-2]] (tu/gene-samples 2)
-          samples [(dissoc gene-1 :gene/cgc-name)
-                   (-> gene-2
-                       (assoc :gene/species (:gene/species gene-1))
+    (let [[[from-id into-id] _ [gene-from gene-into]] (tu/gene-samples 2)
+          samples [(dissoc gene-from :gene/cgc-name)
+                   (-> gene-into
+                       (assoc :gene/species (:gene/species gene-from))
                        (dissoc :gene/sequence-name))]]
       (tu/with-fixtures
         samples
         (fn check-provenance [conn]
           (let [db (d/db conn)
                 user-email "tester@wormbase.org"
-                params (-> {:gene/biotype :biotype/transposon}
-                           (cons gene-ids)
-                           (concat [:current-user user-email]))
-                response (apply merge-genes params)
-                prov (query-provenance conn
-                                       (first gene-ids)
-                                       (second gene-ids))
-                [src tgt] (map #(d/entity db [:gene/id %]) gene-ids)]
+                response (merge-genes {:gene/biotype :biotype/transposon}
+                                      from-id
+                                      into-id
+                                      :current-user user-email)
+                prov (query-provenance conn from-id into-id)
+                [src tgt] (map #(d/entity db [:gene/id %])
+                               [from-id into-id])]
             (t/is (-> prov :provenance/when inst?))
-            (t/is (= (:provenance/merged-from prov)
-                     (first gene-ids)))
+            (t/is (= (:provenance/merged-into prov) into-id))
+            (t/is (= (:provenance/merged-from prov) from-id))
             (t/is (= (:provenance/who prov) user-email))
             ;; TODO: this should be dependent on the client used for the request.
             ;;       at the momment, defaults to web-form.
             (t/is (= (:provenance/how prov) :agent/web-form))))))))
+
+(t/deftest undo-merge
+  (t/testing "Undoing a merge operation."
+    (let [species :species/c-elegans
+          merged-into "WBGene00000001"
+          merged-from "WBGene00000002"
+          from-seq-name (tu/gen-valid-seq-name species)
+          into-seq-name (tu/gen-valid-seq-name species)
+          from-gene {:db/id from-seq-name
+                     :gene/id merged-from
+                     :gene/sequence-name from-seq-name
+                     :gene/species [:species/id species]
+                     :gene/status :gene.status/dead
+                     :gene/biotype :biotype/cds}
+          into-gene {:db/id into-seq-name
+                     :gene/id merged-into
+                     :gene/species [:species/id species]
+                     :gene/sequence-name into-seq-name
+                     :gene/cgc-name (tu/gen-valid-cgc-name species)
+                     :gene/status :gene.status/live
+                     :gene/biotype :biotype/transcript}
+          init-txes [from-gene
+                     into-gene
+                     {:db/id "datomic.tx"
+                      :provenance/merged-from from-seq-name
+                      :provenance/merged-into into-seq-name
+                      :provenance/why
+                      "a gene that has been merged for testing undo"
+                      :provenance/how :agent/script}]
+          conn (db-testing/fixture-conn)]
+      (with-redefs [owdb/connection (fn get-fixture-conn [] conn)
+                    owdb/db (fn get-db [_] (d/db conn))]
+        (let [init-tx-res @(d/transact-async conn init-txes)
+              _ (prn (ownu/datom-table (:db-after init-tx-res)
+                                       (:tx-data init-tx-res)))
+              tx (d/q '[:find ?tx .
+                        :in $ ?from-lur ?into-lur
+                        :where
+                        [?from-lur :gene/status :gene.status/dead ?tx]
+                        [?tx :provenance/merged-from ?from-lur]
+                        [?tx :provenance/merged-into ?into-lur]
+                        ]
+                      (-> init-tx-res :db-after d/history)
+                      [:gene/id merged-from]
+                      [:gene/id merged-into])
+              xxx (println "TX with merge provenence is:" (format "0x%x" tx))
+              user-email "tester@wormbase.org"
+              [status body] (undo-merge-genes merged-from
+                                              merged-into
+                                              :current-user user-email)]
+          (t/is (= status 200) (pr-str body))
+          (t/is (map? body) (type body))
+          (t/is (= (:dead body) merged-from) (pr-str body))
+          (t/is (= (:live body) merged-into) (pr-str body)))))))

--- a/test/integration/test_merge_genes.clj
+++ b/test/integration/test_merge_genes.clj
@@ -183,8 +183,6 @@
       (with-redefs [owdb/connection (fn get-fixture-conn [] conn)
                     owdb/db (fn get-db [_] (d/db conn))]
         (let [init-tx-res @(d/transact-async conn init-txes)
-              _ (prn (ownu/datom-table (:db-after init-tx-res)
-                                       (:tx-data init-tx-res)))
               tx (d/q '[:find ?tx .
                         :in $ ?from-lur ?into-lur
                         :where

--- a/test/integration/test_split_gene.clj
+++ b/test/integration/test_split_gene.clj
@@ -228,8 +228,7 @@
                        :provenance/why
                        "a gene that has been split for testing undo"
                        :provenance/how :agent/script}]]
-          ;conn (db-testing/fixture-conn)
-          conn owdb/conn]
+          conn (db-testing/fixture-conn)]
       (with-redefs [owdb/connection (fn get-fixture-conn [] conn)
                     owdb/db (fn get-db [_] (d/db conn))]
         (doseq [init-tx init-txes]
@@ -260,7 +259,6 @@
                 [from-g into-g] (map #(d/entity db [:gene/id %])
                                      [split-from split-into])]
             (t/is (= (:gene/status from-g) :gene.status/live))
-            ;; TODO: never retract :gene/id and :gene/status and enable this check
             (t/is (= (:gene/status into-g) :gene.status/dead)
                   (str "Into gene:"
                        (d/q '[:find ?e ?aname ?v ?added

--- a/test/org/wormbase/fake_auth.clj
+++ b/test/org/wormbase/fake_auth.clj
@@ -1,8 +1,10 @@
 (ns org.wormbase.fake-auth
-  (:require [org.wormbase.names.auth :as own-auth]
-            [cheshire.core :as json]
-            ;[clojure.tools.logging :as log]
-            ))
+  (:require
+   ;; TODO: loggigng
+   ;; [clojure.tools.logging :as log]
+   [cheshire.core :as json]
+   [environ.core :as environ]
+   [org.wormbase.names.auth :as own-auth]))
 
 (def tokens {"tester@wormbase.org" "TOKEN_HERE_tester1"
              "tester2@wormbase.org" "TOKEN_HERE_tester2"
@@ -20,6 +22,7 @@
  (var own-auth/who-am-i)
  (fn fake-google-people-me-api [real-fn]
    (fn [url]
+     ;; TODO: use logging
      (println "NOTICE: Faking requests to Google APIs")
      {:body (json/generate-string
              {:resourceName "people/123213123123"

--- a/test/org/wormbase/test_dbfns.clj
+++ b/test/org/wormbase/test_dbfns.clj
@@ -197,7 +197,7 @@
   (let [sn (-> sample
                :gene/species
                :species/id
-               tu/gen-valid-seq-name-for-species)]
+               tu/gen-valid-seq-name)]
     (if (= sn (:gene/sequence-name sample))
       (recur sample)
       sn)))

--- a/test/org/wormbase/test_utils.clj
+++ b/test/org/wormbase/test_utils.clj
@@ -18,7 +18,9 @@
    [peridot.core :as p]
    [spec-tools.core :as stc]
    [datomic.api :as d])
-  (:import (java.io InputStream)))
+  (:import
+   (clojure.lang ExceptionInfo)
+   (java.io InputStream)))
 
 ;; TODO: Unify way of creating muuntaja formats "instance"?
 ;;       (Duplication as per o.w.n/service.clj - which does it correctly!)
@@ -49,9 +51,9 @@
         body (if (instance? String body)
                (try
                  (muuntaja/decode mformats "application/edn" body)
-                 (catch clojure.lang.ExceptionInfo jpe
-                   (print-decode-err jpe body)
-                   (throw jpe)))
+                 (catch ExceptionInfo exc
+                   (print-decode-err exc body)
+                   (throw exc)))
                body)]
     body))
 
@@ -120,6 +122,16 @@
                        :params params))]
     [status (parse-body body)]))
 
+(defn delete [app uri content-type headers]
+  (let [request (-> (p/session app)
+                    (p/request uri
+                               :request-method :delete
+                               :headers (or headers {})
+                               :content-type (or content-type
+                                                 "application/edn")))
+        {{:keys [status body response-headers]} :response} request]
+    [status (read-body body) response-headers]))
+
 (defn raw-put-or-post* [app uri method data content-type headers]
   (let [request (-> (p/session app)
                     (p/request uri
@@ -175,7 +187,7 @@
                           (stc/deserialize suspec)
                           body)))))
 
-(defn- map->set [m]
+(defn map->set [m]
   (assert (map? m))
   (some->> (apply vector m)
            (flatten)

--- a/test/org/wormbase/test_utils.clj
+++ b/test/org/wormbase/test_utils.clj
@@ -123,17 +123,19 @@
     [status (parse-body body)]))
 
 (defn delete [app uri content-type headers]
-  (let [request (-> (p/session app)
+  (let [request (-> app
+                    p/session
                     (p/request uri
                                :request-method :delete
                                :headers (or headers {})
                                :content-type (or content-type
                                                  "application/edn")))
         {{:keys [status body response-headers]} :response} request]
-    [status (read-body body) response-headers]))
+    [status (parse-body body) response-headers]))
 
 (defn raw-put-or-post* [app uri method data content-type headers]
-  (let [request (-> (p/session app)
+  (let [request (-> app
+                    p/session
                     (p/request uri
                                :request-method method
                                :headers (or headers {})
@@ -270,13 +272,17 @@
                     :provenance/why
                     :provenance/how])))
 
-(defn gen-valid-seq-name [species]
+(defn gen-valid-name [name-kw species]
   (-> species
       owsg/name-patterns
-      :gene/sequence-name
+      name-kw
       sg/string-generator
       (gen/sample 1)
       first))
+
+(def gen-valid-seq-name (partial gen-valid-name :gene/sequence-name))
+
+(def gen-valid-cgc-name (partial gen-valid-name :gene/cgc-name))
 
 (defn gene-samples [n]
   (assert (int? n))

--- a/test/org/wormbase/test_utils.clj
+++ b/test/org/wormbase/test_utils.clj
@@ -258,7 +258,7 @@
                     :provenance/why
                     :provenance/how])))
 
-(defn gen-valid-seq-name-for-species [species]
+(defn gen-valid-seq-name [species]
   (-> species
       owsg/name-patterns
       :gene/sequence-name
@@ -280,7 +280,7 @@
                     (let [sn (-> m
                                  :gene/species
                                  :species/id
-                                 gen-valid-seq-name-for-species)]
+                                 gen-valid-seq-name)]
                       (assoc m :gene/sequence-name sn)))))
         gene-ids (map :gene/id (flatten gene-refs))]
     (if-let [dup-seq-names? (->> data-samples


### PR DESCRIPTION
Implement undoing of gene merge.

Simpler than undo split, since the no new entity was created by the transaction we're undoing.
This also introduces a [fix][1] for provenance, where I wasn't setting `:db/id "datomic.tx` in the transaction data.

[1]: https://github.com/WormBase/names/compare/develop...feature/undo-merge-genes?expand=1#diff-1abe7393d19b5e5e3b6ecf1f2b4f50afR91