### PR TITLE
Feature/all seed data as edn

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # wormbase-names
 
-Facilitate the sharing of identifiers of certain WormBase types for ACeDB.
+Facilitate the sharing of identifiers and names of a subset of
+WormBase data types.
 
-The ACeDB does not support concurrent writes, so a "name-server"
-service is required to coordinate ACeDB curation.
+ACeDB does not support concurrent writes, so a brokering "name-server"
+service has historically been required to coordinate curation activity.
 
 This library intends to provide:
 
@@ -29,6 +30,9 @@ read in upon starting the web-service, idemopotently using
 
 Provenance (who, when, where and why) is
 modelled as attributes on transactions.
+
+The excewption being that a data-types' status (dead / live /
+supressed) is modelled on the entity, not the transaction.
 
 The latest alpha version of [clojure][2] is used to facilitate the use
 of [clojure.spec][3] to provide validation and test-data-generation for

--- a/resources/schema/definitions.edn
+++ b/resources/schema/definitions.edn
@@ -1,20 +1,4 @@
-[#:db{:ident :agent/id,
-      :valueType :db.type/keyword,
-      :cardinality :db.cardinality/one,
-      :unique :db.unique/value}
- #:db{:ident :org.wormbase.names.agent/console,
-      :valueType :db.type/keyword,
-      :cardinality :db.cardinality/one,
-      :unique :db.unique/value}
- #:db{:ident :org.wormbase.names.agent/web,
-      :valueType :db.type/keyword,
-      :cardinality :db.cardinality/one,
-      :unique :db.unique/value}
- #:db{:ident :biotype/transcript}
- #:db{:ident :biotype/transposon}
- #:db{:ident :biotype/psuedogene}
- #:db{:ident :biotype/cds}
- #:db{:ident :gene/biotype,
+[#:db{:ident :gene/biotype,
       :valueType :db.type/ref,
       :cardinality :db.cardinality/one}
  #:db{:ident :gene/sequence-name,
@@ -35,9 +19,6 @@
  #:db{:ident :gene/status,
       :valueType :db.type/ref,
       :cardinality :db.cardinality/one}
- #:db{:ident :gene.status/dead}
- #:db{:ident :gene.status/suppressed}
- #:db{:ident :gene.status/live}
  #:db{:ident :provenance/compensates
       :valueType :db.type/ref
       :cardinality :db.cardinality/one}
@@ -56,7 +37,7 @@
  #:db{:ident :provenance/merged-from,
       :valueType :db.type/ref,
       :cardinality :db.cardinality/one}
-  #:db{:ident :provenance/merged-into,
+ #:db{:ident :provenance/merged-into,
       :valueType :db.type/ref,
       :cardinality :db.cardinality/one}
  #:db{:ident :provenance/split-from,

--- a/resources/schema/seed-data.edn
+++ b/resources/schema/seed-data.edn
@@ -1,0 +1,45 @@
+[;; biotypes
+ #:db{:ident :biotype/transcript}
+ #:db{:ident :biotype/transposon}
+ #:db{:ident :biotype/psuedogene}
+ #:db{:ident :biotype/cds}
+
+ ;; species
+ #:species{:latin-name "Caenorhabditis elegans"
+           :id :species/c-elegans}
+ #:species{:latin-name "Caenorhabditis briggsae"
+           :id :species/c-briggsae}
+ #:species{:latin-name "Caenorhabditis remanei"
+           :id :species/c-remanei}
+ #:species{:latin-name "Caenorhabditis brenneri"
+           :id :species/c-brenneri}
+ #:species{:latin-name "Pristionchus pacificus"
+           :id :species/p-pacificus}
+ #:species{:latin-name "Caenorhabditis japonica"
+           :id :species/c-japonica}
+ #:species{:latin-name "Brugia malayi"
+           :id :species/b-malayi}
+ #:species{:latin-name "Onchocerca volvulus"
+           :id :species/o-volvulus}
+ #:species{:latin-name "Strongyloides ratti"
+           :id :species/s-ratti}
+
+ ;; templates for identifiers
+ #:template{:format "WBGene%08d", :describes :gene/id}
+ #:template{:format "WBsf%12d", :describes :feature/id}
+ #:template{:format "WBVar%08d", :describes :variation/id}
+
+ ;; agent
+ #:db{:ident :org.wormbase.names.agent/web}
+ #:db{:ident :org.wormbase.names.agent/console}
+
+ ;; gene status
+ #:db{:ident :gene.status/dead}
+ #:db{:ident :gene.status/suppressed}
+ #:db{:ident :gene.status/live}
+ ;; person (user)
+ #:person{:roles #{:person.role/admin},
+          :google-id
+          111925262522292127085N,
+          :email
+          "matthew.russell@wormbase.org"}]

--- a/src/org/wormbase/db/schema.clj
+++ b/src/org/wormbase/db/schema.clj
@@ -3,21 +3,8 @@
    [clojure.edn :as edn]
    [clojure.java.io :as io]
    [datomic.api :as d]
-   [io.rkn.conformity :as c]
-   [org.wormbase.species :as ows]
-   [org.wormbase.names.agent :as own-agent])
+   [io.rkn.conformity :as c])
   (:import (java.io PushbackReader)))
-
-;; TODO: not sure the canonical species listing should "live" here...
-(def worms ["Caenorhabditis elegans"
-            "Caenorhabditis briggsae"
-            "Caenorhabditis remanei"
-            "Caenorhabditis brenneri"
-            "Pristionchus pacificus"
-            "Caenorhabditis japonica"
-            "Brugia malayi"
-            "Onchocerca volvulus"
-            "Strongyloides ratti"])
 
 (defn definitions [db]
   (d/q '[:find [?attr ...]
@@ -28,10 +15,10 @@
          [(namespace ?attr) ?ns]
          [(= ?ns ?include-ns)]]
        db
-       #{"agent"
-         "biotype"
+       #{"biotype"
          "gene"
          "gene.status"
+         "org.wormbase.names.agent"
          "provenance"
          "species"
          "template"
@@ -69,10 +56,8 @@
           init-schema [(concat db-fns schema-txes)]]
       ;; NOTE: datomic-schema-grapher.core/graph-datomic won't show the
       ;;       relations without some data installed.
-      ;;       i.e schema alone will not draw the arrows between refs.
-      ;; (println txes)
-      ;; (c/ensure-conforms conn {schema-ident {:txes db-fns}})
+      ;;       i.e schema alone will not draw the  between refs.
+      ;;           (arrows on digagrea)
       (c/ensure-conforms conn {:initial-schema {:txes init-schema}})
-      (c/ensure-conforms conn {:seed-data {:txes [seed-data]}})
-      )))
+      (c/ensure-conforms conn {:seed-data {:txes [seed-data]}}))))
 

--- a/src/org/wormbase/names/gene.clj
+++ b/src/org/wormbase/names/gene.clj
@@ -1,22 +1,15 @@
 (ns org.wormbase.names.gene
   (:require
    [clojure.spec.alpha :as s]
-   [clojure.string :as str]
-   [clj-http.client :as http]
    [compojure.api.sweet :as sweet]
    [datomic.api :as d]
-   [expound.core :as expound]
    [java-time :as jt]
    [org.wormbase.db :as owdb]
-   [org.wormbase.names.auth :as own-auth]
    [org.wormbase.names.agent :as own-agent]
    [org.wormbase.names.util :as ownu]
-   [org.wormbase.names.util :refer [namespace-keywords]]
    [org.wormbase.specs.common :as owsc]
    [org.wormbase.specs.gene :as owsg]
-   [org.wormbase.specs.provenance :as owsp]
-   [ring.util.http-response :as http-response]
-   [org.wormbase.names.util :as util])
+   [ring.util.http-response :as http-response])
   (:refer-clojure :exclude [merge]))
 
 (defn- extract-id [tx-result]

--- a/src/org/wormbase/names/gene.clj
+++ b/src/org/wormbase/names/gene.clj
@@ -16,7 +16,7 @@
    [org.wormbase.specs.gene :as owsg]
    [org.wormbase.specs.provenance :as owsp]
    [ring.util.http-response :as http-response]
-   [org.wormbase.test-utils :as tu])
+   [org.wormbase.names.util :as util])
   (:refer-clojure :exclude [merge]))
 
 (defn- extract-id [tx-result]

--- a/test/integration/test_update_names.clj
+++ b/test/integration/test_update_names.clj
@@ -62,7 +62,7 @@
                   ent (d/entity (d/db conn) [:gene/id identifier])]
               (tu/status-is? status 200 (pr-str response))
               (let [act-prov (tu/query-provenance conn identifier)]
-                (t/is (= (:provenance/how act-prov) ::own-agent/console)
+                (t/is (= (-> act-prov :provenance/how) ::own-agent/console)
                       (pr-str act-prov))
                 (t/is (= (:provenance/why act-prov) reason))
                 (t/is (= (:provenance/who act-prov)

--- a/test/org/wormbase/test_utils.clj
+++ b/test/org/wormbase/test_utils.clj
@@ -230,7 +230,7 @@
 
 (defn with-fixtures [data-samples test-fn
                      & {:keys [how whence why person status]
-                        :or {how [:agent/id ::own-agent/console]
+                        :or {how ::own-agent/console
                              whence (jt/to-java-date (jt/instant))
                              person [:person/email "tester@wormbase.org"]}}]
   (let [conn (db-testing/fixture-conn)
@@ -264,7 +264,7 @@
                   [(get-else $ ?tx :provenance/when :unset) ?when]
                   [(get-else $ ?tx :provenance/why "Dunno") ?why]
                   [(get-else $ ?tx :provenance/how :unset) ?how-id]
-                  [?how-id :agent/id ?how]]
+                  [?how-id :db/ident ?how]]
                 (-> conn d/db d/history)
                 [:gene/id gene-id])
            (zipmap [:tx-id


### PR DESCRIPTION
Unifies the way data initially gets into the database (all as .edn files in `/resources/schmea`).
