### PR TITLE
Feature/geneace relay

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,7 @@
    ;; [org.clojure/tools.logging "0.4.0"]
    [org.clojure/core.cache "0.6.5"]
    [aero "1.1.2"]
+   [amazonica "0.3.121"]
    [bk/ring-gzip "0.2.1"]
    [buddy/buddy-auth "2.1.0"]
    [cheshire "5.8.0"]
@@ -23,7 +24,7 @@
                                       com.sun.jdmk/jmxtools
                                       com.sun.jmx/jmxri]]
    [me.raynes/fs "1.4.6"]
-   [metosin/compojure-api "2.0.0-alpha16" :exclusions [potemkin
+   [metosin/compojure-api "2.0.0-alpha19" :exclusions [potemkin
                                                        instaparse]]
    [metosin/spec-tools "0.5.1"]
    [mount "0.1.12"]

--- a/src/org/wormbase/db.clj
+++ b/src/org/wormbase/db.clj
@@ -50,13 +50,16 @@
         state-key (pr-str #'conn)]
     (states state-key)))
 
-;; factored out so can be mocked in tests.
+;; factoring out so can be mocked in tests.
+
 (defn db
   [conn]
   (d/db conn))
 
 (defn connection []
   conn)
+
+;; end factoring
 
 (defn wrap-datomic
   "Annotates request with datomic connection and current db."

--- a/src/org/wormbase/names/ace_relay.clj
+++ b/src/org/wormbase/names/ace_relay.clj
@@ -1,0 +1,81 @@
+(ns org.wormbase.names.ace-relay
+  "Relay messages for consumption by parties interested (primarily ACeDB clients).
+  Ueses Amazon Simple Queueing Service (SQS) as the message queue provider."
+  (:require
+   [amazonica.aws.sqs :as sqs]
+   [datomic.api :as d]
+   [mount.core :as mount :refer [defstate]]
+   [org.wormbase.db :as owdb]
+   [org.wormbase.names.util :as ownu]))
+
+(def ace-queue-conf {:queue-name "org-wormbase-names-ace-relay_messages"
+                     :attributes
+                     {:VisibilityTimeout 30 ;; sec
+                      :MaximumMessageSize 65536 ;; bytes
+                      :MessageRetentionPeriod 3628800 ;; sec
+                      :ReceiveMessageWaitTimeSeconds 10}})
+
+;; TODO: superfluous?
+;; (defmulti send-message (fn [tx] :noop))
+;; (defmethod send-message :event/new-gene [tx-data])
+;; (defmethod send-message :event/update-gene [tx-data])
+;; (defmethod send-message :event/kill-gene [tx-data])
+;; (defmethod send-message :event/split-gene [tx-data]) 
+;; (defmethod send-message :event/merge-genes [tx-data])
+
+(defn- create-queue [& args]
+  ;; TODO: really call the sqs fn with args of course:
+  ;; sqs/create-queue
+  (println "Faking AWS SQS CREATE QUEUE")
+  "urn:fake:fake:fake")
+
+(defn ace-queue []
+  (if-let [aq (-> ace-queue-conf :queue-name sqs/find-queue)]
+    aq
+    (apply create-queue (-> ace-queue-conf vec flatten))))
+
+(defn read-changes [{:keys [db-after tx-data] :as report}]
+  (d/q '[:find ?aname ?val
+         :in $ [[_ ?a ?val]]
+         :where
+         [?a :db/ident ?aname]]
+       db-after
+       tx-data))
+
+(defn send-changes-via-aws-sqs [queue changes]
+  (sqs/send-message queue changes))
+
+(defn monitor-tx-changes
+  "Monitor datomic transactions for events that are desired for later consumption
+  by clients wishing to process the same update(s) in ACeDB.
+
+  `send-changes-fn` should be a functio accepting a map of changes to be sent.
+  e.g: via AWS SQS, or possibly email."
+  [tx-report-queue send-changes-fn]
+  (while true
+    ;; TODO: factor out fn that works on the report queue? (.take...)
+    (let [report (.take tx-report-queue) ;; blocks until message is availableb
+          db-after (:db-after report)
+          changes (->> report
+                       read-changes
+                       (into {})
+                       (ownu/resolve-refs db-after))]
+      (comment "TODO: LOGGING")
+      (println "CHANGES:" changes)
+      (send-changes-fn changes))))
+
+(defn start-queue-monitor [conn send-changes-fn]
+  (comment "TODO: LOGGING")
+  (println "Start Queue Service")
+  (let [tx-report-queue (d/tx-report-queue conn)]
+    (future (monitor-tx-changes tx-report-queue send-changes-fn))))
+
+(mount/defstate change-queue-monitor
+  :start (fn []
+           (start-queue-monitor
+            owdb/conn
+            (partial send-changes-via-aws-sqs (ace-queue))))
+  :stop (fn []
+          (println "CANCELLING FUTURE")
+          (future-cancel change-queue-monitor)
+          (println "Stop Queue Service")))

--- a/src/org/wormbase/names/errhandlers.clj
+++ b/src/org/wormbase/names/errhandlers.clj
@@ -117,7 +117,7 @@
     (http-response/unauthorized "Access denied")
     (http-response/forbidden)))
 
-(def ^{:doc "Error handler function for the compojure.api app"} handlers
+(def ^{:doc "Error handler dispatch map for the compojure.api app"} handlers
   {;; Spec validation errors
    ::ex/request-validation handle-request-validation ;; c-api
    :user/validation-error handle-validation-error

--- a/src/org/wormbase/names/event_broadcast.clj
+++ b/src/org/wormbase/names/event_broadcast.clj
@@ -16,8 +16,6 @@
                       :ReceiveMessageWaitTimeSeconds 10}})
 
 (defn- create-queue [& args]
-  ;; TODO: really call the sqs fn with args of course:
-  ;; sqs/create-queue
   (apply sqs/create-queue args))
 
 (defn sqs-queue []

--- a/src/org/wormbase/names/util.clj
+++ b/src/org/wormbase/names/util.clj
@@ -66,3 +66,19 @@
            "tx" (format "0x%x" tx)
            "added" added}))
        (pp/print-table ["part" "e" "a" "v" "tx" "added"])))
+
+(defn- resolve-ref [db m k v]
+  (cond
+    (pos-int? v)
+    (if-let [ident (d/ident db v)]
+      (assoc m k ident)
+      (assoc m k (->> v (d/entity db) entity->map)))
+    :default
+    (assoc m k v)))
+
+(defn resolve-refs [db entity-like-mapping]
+  (walk/prewalk (fn [xs]
+                  (if (map? xs)
+                    (reduce-kv (partial resolve-ref db) (empty xs) xs)
+                    xs))
+                entity-like-mapping))

--- a/test/org/wormbase/db_testing.clj
+++ b/test/org/wormbase/db_testing.clj
@@ -7,7 +7,7 @@
    [mount.core :as mount]
    [org.wormbase.db :as owdb]
    [org.wormbase.db.schema :as schema]
-   [org.wormbase.names.ace-relay :as own-ar]))
+   [org.wormbase.names.event-broadcast :as own-eb]))
 
 ;;; fixture caching and general approach taken verbatim from:
 ;;; https://vvvvalvalval.github.io/posts/2016-07-24-datomic-web-app-a-practical-guide.html
@@ -47,9 +47,9 @@
                  (jt/to-millis-from-epoch (jt/instant)))]
     (let [conn (fixture-conn)
           tx-reqort-queue (d/tx-report-queue conn)
-          monitor (partial own-ar/start-queue-monitor conn send-changes-test)]
+          monitor (partial own-eb/start-queue-monitor conn send-changes-test)]
       (mount/start-with {#'owdb/conn conn
-                         #'own-ar/change-queue-monitor (monitor)})
+                         #'own-eb/change-queue-monitor (monitor)})
       (f)
       (owdb/checked-delete uri)
       (mount/stop))))


### PR DESCRIPTION
Implements broadcasting of transaction events to  interested parties (intended for geneace consumption)

Implemented relaying of transaction to a queue for later consumption
 - Implement  sending message to a single provide (AWS SQS)
 - Implementation allows substitution of provide by changing the
   `send-message-fn` passed to the mount state:
    `org.wormbase.names.event-broadcast/change-queue-monitor`
 - Change queue monitor runs in a separate thread.
 - In tests, the send-message-fn just prints (no AWS SQS involvement)

Only events where the provenance contains "how" of :agent/web (i.e those requests eminating via the web UI) will be broadcast (by default).
;