### PR TITLE
Implement broadcast transaction report messages for geneace.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,6 +14,7 @@
    [cheshire "5.8.0"]
    [clj-http "3.7.0"]
    [clojure.java-time "0.3.1"]
+   [com.draines/postal "2.0.2"]
    [danlentz/clj-uuid "0.1.7"]
    [environ "1.1.0"]
    [expound "0.5.0"]

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -1,4 +1,15 @@
-{:google-apps
+{:event-broadcast
+ {:gmail #include #join [#env HOME "/.wb-ns-gmail-secrets.edn"]
+  :aws-sqs
+  {:queue-name "org-wormbase-names-tx_messages"
+   :attributes
+   {:VisibilityTimeout 30 ;; sec
+    :MaximumMessageSize 65536 ;; bytes
+    :MessageRetentionPeriod 1209600 ;; sec
+    :ReceiveMessageWaitTimeSeconds 10}}
+  :aws-s3
+  {:bucket-name "wormbase"}}
+ :google-apps
  {:web #include #join [#env HOME "/.wb-ns-google-secrets-web.edn"]
   :console #include #join [#env HOME "/.wb-ns-google-secrets-console.edn"]}
  :cookie-name "WBNS-COOKIE"

--- a/src/org/wormbase/names/event_broadcast/aws_s3.clj
+++ b/src/org/wormbase/names/event_broadcast/aws_s3.clj
@@ -1,0 +1,36 @@
+(ns org.wormbase.names.event-broadcast.aws-s3
+  (:require
+   [clojure.edn :as edn]
+   [amazonica.aws.s3 :as s3]
+   [org.wormbase.names.util :as ownu]
+   [org.wormbase.names.event-broadcast.proto :as evb-proto]
+   [clojure.string :as str])
+  (:import
+   (java.io ByteArrayInputStream)))
+
+(defn derive-bucket-key [event]
+  (let [parts ["name-server"
+               "events"
+               (name (:provenance/what event))
+               (str (:tx-id event) ".edn")]]
+    (str/join "/" parts)))
+
+(defn- bucket-name [tx-event-brodcaster]
+  (get-in tx-event-brodcaster [:config :bucket-name]))
+
+(defrecord TxEventBroadcaster [config]
+  evb-proto/TxEventBroadcaster
+  (message-persisted? [this changes]
+    (not (nil? (s3/get-object-metadata
+                :bucket-name (bucket-name this)
+                :key (derive-bucket-key changes)))))
+  (send-message [this changes]
+    (let [data (.getBytes (pr-str changes) "UTF-8")
+          input-stream (ByteArrayInputStream. data)]
+      (s3/put-object :bucket-name (get-in this [:config :bucket-name])
+                     :key (derive-bucket-key changes)
+                     :input-stream input-stream
+                     :metadata {:content-length (count data)}
+                     :return-values "ALL_OLD"))))
+
+(def make (partial evb-proto/make map->TxEventBroadcaster :aws-s3))

--- a/src/org/wormbase/names/event_broadcast/aws_sqs.clj
+++ b/src/org/wormbase/names/event_broadcast/aws_sqs.clj
@@ -1,0 +1,24 @@
+(ns org.wormbase.names.event-broadcast.aws-sqs
+  (:require
+   [amazonica.aws.sqs :as sqs]
+   [org.wormbase.names.util :as ownu]
+   [org.wormbase.names.event-broadcast.proto :as evb-proto]))
+
+(defn- sqs-queue [config]
+  (if-let [aq (-> config :queue-name sqs/find-queue)]
+    aq
+    (apply sqs/create-queue (-> config vec flatten))))
+
+(defrecord TxEventBroadcaster [config]
+  evb-proto/TxEventBroadcaster
+  (configure [this]
+    (assoc-in this [:config :queue] (sqs-queue)))
+  (message-persisted? [this message-id]
+    (let [msgs (:messages (sqs/receive-message
+                           :queue-url (get-in this [:config :queue])
+                           :delete false))]
+      (not-empty (filter #(= (:message-id %) message-id) msgs))))
+  (send-message [this changes]
+    (sqs/send-message (get-in this [:config :queue]) changes)))
+
+(def make (partial evb-proto/make map->TxEventBroadcaster :aws-sqs))

--- a/src/org/wormbase/names/event_broadcast/gmail.clj
+++ b/src/org/wormbase/names/event_broadcast/gmail.clj
@@ -1,0 +1,23 @@
+(ns org.wormbase.names.event-broadcast.gmail
+  (:require
+   [org.wormbase.names.util :as ownu]
+   [org.wormbase.names.event-broadcast.proto :as evb-proto]
+   [postal.core :as postal]
+   [clojure.string :as str]))
+
+(defn derive-message-subject [event]
+  (str (:event/type event)))
+
+(defrecord TxEventBroadcaster [config]
+  evb-proto/TxEventBroadcaster
+  (send-message [this changes]
+    (let [conn (:config this)
+          subject (derive-message-subject changes)]
+      (postal/send-message conn
+                           {:from (:user conn)
+                            :to (:group-list conn)
+                            :subject subject}))))
+
+
+(def make (partial evb-proto/make map->TxEventBroadcaster :gmail))
+

--- a/src/org/wormbase/names/event_broadcast/proto.clj
+++ b/src/org/wormbase/names/event_broadcast/proto.clj
@@ -1,0 +1,13 @@
+(ns org.wormbase.names.event-broadcast.proto
+  (:require [org.wormbase.names.util :as ownu]))
+
+
+(defprotocol TxEventBroadcaster
+  (message-persisted? [this message-id])
+  (send-message [this changes])
+  (configure [this]))
+
+
+(defn make [ctor config-kw]
+  (let [config (get-in (ownu/read-app-config) [:event-broadcast config-kw])]
+    (ctor {:config config})))

--- a/src/org/wormbase/names/person.clj
+++ b/src/org/wormbase/names/person.clj
@@ -19,7 +19,7 @@
     (if (s/valid? spec person)
       (let [tempid "datomic.tx"
             prov (ownp/assoc-provenence request person :event/new-person)
-            tx-res @(d/transact conn [person prov])
+            tx-res @(d/transact conn [(assoc person :person/active? true) prov])
             pid (owdb/extract-id tx-res :person/id)]
         (http-response/created (str "/person/" pid) person))
       (let [problems (s/explain-data spec person)]


### PR DESCRIPTION
 * Abstracted method into protocol
 * Implemented 3 separate "transports" (AWS SQS, S3 and gmail)
 * S3 is the default
 * Checks message is persisted in storage before removal from queue.