### PR TITLE
Feature/api format default to json

### DIFF
--- a/src/wormbase/names/errhandlers.clj
+++ b/src/wormbase/names/errhandlers.clj
@@ -4,6 +4,7 @@
    [buddy.auth :refer [authenticated?]]
    [compojure.api.exception :as ex]
    [environ.core :as environ]
+   [expound.alpha :refer [expound-str]]
    [wormbase.db :as ow-db]
    ;;   TODO: better API error messages
    ;;   [phrase.alpha :as phrase]
@@ -44,7 +45,7 @@
       (f (if (or (= type :validation-error) (= (name type) "validation-error"))
            (let [info* (ex-data err)
                  problems (if info*
-                            (:problems info*))
+                            (:problems (str info*)))
                  info* (when problems
                          (assoc info* :problems problems))]
                                 ;; (pr-str problems)))]
@@ -59,7 +60,7 @@
 (defn handle-validation-error [^Exception exc data request]
   (let [problems (get-in data [:data :problems])
         info (if problems
-               (assoc data :problems problems)
+               (assoc data :problems (str problems))
                data)]
     (respond-bad-request request (assoc-error-message info exc))))
 
@@ -108,7 +109,7 @@
 (defn handle-request-validation
   ([^Exception exc data request]
    (respond-bad-request request {:message (.getMessage exc)
-                                 :problems (:problems data)}))
+                                 :problems (str (:problems data))}))
   ([err]
    err))
 

--- a/src/wormbase/names/gene.clj
+++ b/src/wormbase/names/gene.clj
@@ -6,16 +6,16 @@
    [datomic.api :as d]
    [java-time :as jt]
    [wormbase.db :as owdb]
-   [wormbase.names.agent :as own-agent]
-   [wormbase.names.entity :as owne]
-   [wormbase.names.provenance :as ownp]
-   [wormbase.names.util :as ownu]
-   [wormbase.specs.common :as owsc]
-   [wormbase.specs.gene :as owsg]
+   [wormbase.names.agent :as wna] ;; specs
+   [wormbase.names.entity :as wne]
+   [wormbase.names.provenance :as wnp]
+   [wormbase.names.util :as wnu]
+   [wormbase.specs.common :as wsc]
+   [wormbase.specs.gene :as wsg]
    [ring.util.http-response :as http-response]
    [spec-tools.core :as stc]))
 
-(def identify (partial owne/identify ::owsg/identifier))
+(def identify (partial wne/identify ::wsg/identifier))
 
 (defn validate-names [request data]
   (let [db (:db request)
@@ -57,9 +57,9 @@
   Match any unique gene identifier (cgc, sequence names or id)."
   [request]
   (when-let [pattern (some-> request :query-params :pattern str/trim)]
-    (if (s/valid? ::owsg/find-term pattern)
+    (if (s/valid? ::wsg/find-term pattern)
       (let [db (:db request)
-            term (st/conform ::owsg/find-term pattern)
+            term (stc/conform ::wsg/find-term pattern)
             q-result (d/q '[:find ?gid ?attr ?name
                             :in $ % ?term
                             :where
@@ -76,8 +76,8 @@
         (http-response/ok res))
       (http-response/bad-request {:message "Invalid find term"
                                   :value pattern
-                                  :problems (s/explain-data ::owsg/find-term
-                                                            pattern)}))))
+                                  :problems (str (s/explain-data ::wsg/find-term
+                                                                 pattern))}))))
 
 (defn- transform-result
   "Removes datomic internals from a pull-result map."
@@ -90,7 +90,7 @@
              (dissoc pull-result :db/id)))
 
 (defn about-gene [request identifier]
-  (when (s/valid? ::owsg/identifier identifier)
+  (when (s/valid? ::wsg/identifier identifier)
     (let [db (:db request)
           [lur ent] (identify request identifier)
           info-expr '[*
@@ -102,8 +102,8 @@
 
 (defn new-gene [request]
   (let [payload (:body-params request)
-        data (ownu/select-keys-with-ns payload "gene")
-        spec ::owsg/new
+        data (wnu/select-keys-with-ns payload "gene")
+        spec ::wsg/new
         [_ cdata] (let [conformed (stc/conform spec (validate-names request data))]
                     (if (= ::s/invalid conformed)
                       (let [problems (s/explain-data spec data)]
@@ -112,13 +112,13 @@
                                          :type ::validation-error
                                          :data data})))
                       conformed))
-        prov (ownp/assoc-provenence request payload :event/new-gene)
+        prov (wnp/assoc-provenence request payload :event/new-gene)
         tx-data [[:wormbase.tx-fns/new "gene" cdata] prov]
         tx-result @(d/transact-async (:conn request) tx-data)
         db (:db-after tx-result)
         new-id (owdb/extract-id tx-result :gene/id)
         ent (d/entity db [:gene/id new-id])
-        emap (ownu/entity->map ent)
+        emap (wnu/entity->map ent)
         result {:created emap}]
       (http-response/created "/gene/" result)))
 
@@ -127,21 +127,21 @@
         [lur entity] (identify request identifier)]
     (when entity
       (let [payload (some-> request :body-params)
-            spec ::owsg/update
-            data (ownu/select-keys-with-ns payload "gene")]
-        (if (s/valid? ::owsg/update data)
-          (let [cdata (st/conform spec (validate-names request data))
-                prov (ownp/assoc-provenence request payload :event/update-gene)
+            spec ::wsg/update
+            data (wnu/select-keys-with-ns payload "gene")]
+        (if (s/valid? ::wsg/update data)
+          (let [cdata (stc/conform spec (validate-names request data))
+                prov (wnp/assoc-provenence request payload :event/update-gene)
                 txes [[:wormbase.tx-fns/update-gene lur cdata]
                       prov]
                 tx-result @(d/transact-async conn txes)
                 ent (d/entity db lur)]
             (if (:db-after tx-result)
-              (http-response/ok {:updated (ownu/entity->map ent)})
+              (http-response/ok {:updated (wnu/entity->map ent)})
               (http-response/not-found
                (format "Gene '%s' does not exist" (last lur)))))
           (throw (ex-info "Not valid according to spec."
-                          {:problems (s/explain-data spec data)
+                          {:problems (str (s/explain-data spec data))
                            :type ::validation-error
                            :data data})))))))
 
@@ -157,9 +157,9 @@
     (when-not (and (s/valid? :gene/biotype into-biotype)
                    (owdb/ident-exists? db into-biotype))
       (throw (ex-info "Invalid biotype"
-                      {:problems (s/explain-data
-                                  :gene/biotype
-                                  into-biotype)
+                      {:problems (str (s/explain-data
+                                       :gene/biotype
+                                       into-biotype))
                        :type ::validation-error})))
     (when (reduce not=
                   (map (comp :species/id :gene/species) [from into]))
@@ -189,7 +189,7 @@
                                            from-id
                                            into-biotype)
         prov (-> request
-                 (ownp/assoc-provenence data :event/merge-genes)
+                 (wnp/assoc-provenence data :event/merge-genes)
                  (assoc :provenance/merged-from from-lur)
                  (assoc :provenance/merged-into into-lur))
         tx-result @(d/transact-async
@@ -199,7 +199,7 @@
       (if-let [db (:db-after tx-result (:tx-data tx-result))]
         (let [[from into] (map #(d/entity db [:gene/id %])
                                [from-id into-id])]
-          (http-response/ok {:updated (ownu/entity->map into)
+          (http-response/ok {:updated (wnu/entity->map into)
                              :statuses
                              {from-id (:gene/status from)
                               into-id (:gene/status into)}}))
@@ -228,45 +228,36 @@
   (let [conn (:conn request)
         db (d/db conn)
         data (some-> request :body-params)
-        spec ::owsg/split]
-    (if (s/valid? spec data)
-      (if-let [[lur existing-gene] (identify request id)]
-        (let [cdata (st/conform spec data)
-              {biotype :gene/biotype product :product} cdata
-              {p-seq-name :gene/sequence-name
-               p-biotype :gene/biotype} product
-              p-seq-name (get-in cdata [:product :gene/sequence-name])
-              prov-from (-> request
-                            (ownp/assoc-provenence cdata :event/split-gene)
-                            (assoc :provenance/split-into p-seq-name)
-                            (assoc :provenance/split-from [:gene/id id]))
-              species (-> existing-gene :gene/species :species/id)
-              tx-result @(d/transact-async
-                          conn
-                          [[:wormbase.tx-fns/split-gene id cdata]
-                           prov-from])
-              db (:db-after tx-result)
-              new-gene-id (-> db
-                              (d/entity [:gene/sequence-name p-seq-name])
-                              :gene/id)
-              [ent product] (map #(d/entity db [:gene/id %]) [id new-gene-id])
-              updated (-> (ownu/entity->map ent)
-                          (select-keys [:gene/id
-                                        :gene/biotype
-                                        :gene/sequence-name])
-                          (assoc :gene/species {:species/id species}))
-              created (ownu/entity->map product)]
-          (http-response/created (str "/gene/" new-gene-id)
-                                 {:updated updated :created created}))
-        (http-response/not-found {:gene/id id :message "Gene not found"}))
-      (let [spec-report (s/explain-data ::owsg/split data)]
-        ;; TODO: finer grained error message here would be good.
-        ;;       e.g (phrase-first {} ::owsg/split spec-report) ->
-        ;;           "biotype missing in split product"
-        (throw (ex-info "Invalid split request"
-                        {:type :user/validation-error
-                         :data data
-                         :problems spec-report}))))))
+        spec ::wsg/split]
+    (if-let [[lur existing-gene] (identify request id)]
+      (let [cdata (stc/conform spec data)
+            {biotype :gene/biotype product :product} cdata
+            {p-seq-name :gene/sequence-name
+             p-biotype :gene/biotype} product
+            p-seq-name (get-in cdata [:product :gene/sequence-name])
+            prov-from (-> request
+                          (wnp/assoc-provenence cdata :event/split-gene)
+                          (assoc :provenance/split-into p-seq-name)
+                          (assoc :provenance/split-from [:gene/id id]))
+            species (-> existing-gene :gene/species :species/id)
+            tx-result @(d/transact-async
+                        conn
+                        [[:wormbase.tx-fns/split-gene id cdata]
+                         prov-from])
+            db (:db-after tx-result)
+            new-gene-id (-> db
+                            (d/entity [:gene/sequence-name p-seq-name])
+                            :gene/id)
+            [ent product] (map #(d/entity db [:gene/id %]) [id new-gene-id])
+            updated (-> (wnu/entity->map ent)
+                        (select-keys [:gene/id
+                                      :gene/biotype
+                                      :gene/sequence-name])
+                        (assoc :gene/species {:species/id species}))
+            created (wnu/entity->map product)]
+        (http-response/created (str "/gene/" new-gene-id)
+                               {:updated updated :created created}))
+      (http-response/not-found {:gene/id id :message "Gene not found"}))))
 
 (defn- invert-split-tx [db e a v tx added?]
   (cond
@@ -314,7 +305,7 @@
                        :lookup-ref lur})))
     (when ent
       (let [payload (some->> request :body-params)
-            prov (ownp/assoc-provenence request payload :event/kill-gene)
+            prov (wnp/assoc-provenence request payload :event/kill-gene)
             tx-result @(d/transact-async
                         (:conn request)
                         [[:wormbase.tx-fns/kill-gene lur] prov])]
@@ -322,9 +313,9 @@
           (http-response/ok {:killed id}))))))
 
 (def default-responses
-  {200 {:schema {:updated ::owsg/updated}}
-   400 {:schema {:errors ::owsc/error-response}}
-   409 {:schema {:conflict ::owsc/conflict-response}}})
+  {200 {:schema {:updated ::wsg/updated}}
+   400 {:schema {:errors ::wsc/error-response}}
+   409 {:schema {:conflict ::wsc/conflict-response}}})
 
 (def routes
   (sweet/routes
@@ -335,17 +326,17 @@
        {:summary "Testing auth session."
         :responses (assoc default-responses
                           200
-                          {:schema ::owsg/find-result})
-        :parameters {:query-params ::owsg/find-request}
+                          {:schema ::wsg/find-result})
+        :parameters {:query-params ::wsg/find-request}
         :x-name ::find-gene
         :handler (fn find-by-any-name [request]
                    (find-gene request))}
        :post
        {:summary "Create new names for a gene (cloned or un-cloned)"
         :x-name ::new-gene
-        :parameters {:body-params ::owsg/new}
-        :responses {201 {:schema {:created ::owsg/created}}
-                    400 {:schema  ::owsc/error-response}}
+        :parameters {:body-params ::wsg/new}
+        :responses {201 {:schema {:created ::wsg/created}}
+                    400 {:schema ::wsc/error-response}}
         :handler new-gene}}))
    (sweet/context "/gene/:identifier" [identifier]
      :tags ["gene"]
@@ -353,21 +344,21 @@
       {:delete
        {:summary "Kill a gene"
         :x-name ::kill-gene
-        :parameters {:body ::owsg/kill}
-        :responses (assoc default-responses 200 {:schema ::owsg/kill})
-        :path-params [identifier :- ::owsg/identifier]
+        :parameters {:body-params ::wsg/kill}
+        :responses (assoc default-responses 200 {:schema ::wsg/kill})
+        :path-params [identifier :- ::wsg/identifier]
         :handler (fn [request]
                    (kill-gene request identifier))}
        :get
        {:summary "Information about a given gene."
         :x-name ::about-gene
-        :responses (assoc default-responses 200 {:schema ::owsg/info})
+        :responses (assoc default-responses 200 {:schema ::wsg/info})
         :handler (fn [request]
                    (about-gene request identifier))}
        :put
        {:summary "Add new names to an existing gene"
         :x-name ::update-gene
-        :parameters {:body ::owsg/update}
+        :parameters {:body-params ::wsg/update}
         :responses (dissoc default-responses 409)
         :handler (fn [request]
                    (update-gene request identifier))}})
@@ -376,9 +367,9 @@
         {:post
          {:summary "Merge one gene with another."
           :x-name ::merge-gene
-          :path-params [identifier ::owsg/identifier
-                        from-identifier ::owsg/identifier]
-          :parameters {:body {:gene/biotype :gene/biotype}}
+          :path-params [identifier ::wsg/identifier
+                        from-identifier ::wsg/identifier]
+          :parameters {:body-params {:gene/biotype :gene/biotype}}
           :responses default-responses
           :handler
           (fn [request]
@@ -386,9 +377,9 @@
          :delete
          {:summary "Undo a merge operation."
           :x-name ::undo-merge-gene
-          :path-params [identifier ::owsg/identifier
-                        from-identifier ::owsg/identifier]
-          :responses (assoc default-responses 200 {:schema ::owsg/undone})
+          :path-params [identifier ::wsg/identifier
+                        from-identifier ::wsg/identifier]
+          :responses (assoc default-responses 200 {:schema ::wsg/undone})
           :handler (fn [request]
                      (undo-merge-gene request from-identifier identifier))}}))
      (sweet/context "/split" []
@@ -396,10 +387,10 @@
         {:post
          {:summary "Split a gene."
           :x-name ::split-genes
-          :path-params [identifier :- ::owsg/identifier]
-          :parameters {:body ::owsg/split}
+          :path-params [identifier :- ::wsg/identifier]
+          :parameters {:body-params ::wsg/split}
           :responses (-> (dissoc default-responses 200)
-                         (assoc 201 {:schema ::owsg/split-response}))
+                         (assoc 201 {:schema ::wsg/split-response}))
           :handler
           (fn [request]
             (split-gene request identifier))}}))
@@ -408,11 +399,11 @@
         {:delete
          {:summary "Undo a split gene operation."
           :x-name ::undo-split-gene
-          :path-params [identifier :- ::owsg/identifier
-                        into-identifier :- ::owsg/identifier]
+          :path-params [identifier :- ::wsg/identifier
+                        into-identifier :- ::wsg/identifier]
           :responses (assoc default-responses
                             200
-                            {:schema ::owsg/undone})
+                            {:schema ::wsg/undone})
           :handler (fn [request]
                      (undo-split-gene request
                                       identifier

--- a/src/wormbase/names/service.clj
+++ b/src/wormbase/names/service.clj
@@ -16,7 +16,7 @@
    [ring.util.http-response :as http-response]
    [buddy.auth :as auth]))
 
-(def default-format "application/edn")
+(def default-format "application/json")
 
 (def ^{:private true
        :doc "Request/Response format configuration"} mformats

--- a/src/wormbase/names/service.clj
+++ b/src/wormbase/names/service.clj
@@ -23,9 +23,9 @@
   (muuntaja/create
     (muuntaja/select-formats
       muuntaja/default-options
-      ["application/edn"
+      ["application/json"
        "application/transit+json"
-       "application/json"])))
+       "application/edn"])))
 
 (defn- wrap-not-found
   "Fallback 404 handler."

--- a/src/wormbase/specs/biotype.clj
+++ b/src/wormbase/specs/biotype.clj
@@ -1,13 +1,15 @@
 (ns wormbase.specs.biotype
-  (:require [clojure.spec.alpha :as s]))
+  (:require
+   [clojure.spec.alpha :as s]
+   [spec-tools.spec :as sts]))
 
-(s/def :biotype/cds keyword?)
+(s/def :biotype/cds sts/keyword?)
 
-(s/def :biotype/psuedogene keyword?)
+(s/def :biotype/psuedogene sts/keyword?)
 
-(s/def :biotype/transcript keyword?)
+(s/def :biotype/transcript sts/keyword?)
 
-(s/def :biotype/transposon keyword?)
+(s/def :biotype/transposon sts/keyword?)
 
 (def all-biotypes #{:biotype/cds
                     :biotype/psuedogene

--- a/src/wormbase/specs/common.clj
+++ b/src/wormbase/specs/common.clj
@@ -1,10 +1,12 @@
 (ns wormbase.specs.common
-  (:require [clojure.spec.alpha :as s]))
+  (:require [clojure.spec.alpha :as s]
+            [spec-tools.core :as stc]
+            [spec-tools.spec :as sts]))
 
-(s/def ::info map?)
+(s/def ::info sts/map?)
 
-(s/def ::spec (s/keys :req-un [::info]))
+(s/def ::spec (stc/spec (s/keys :req-un [::info])))
 
-(s/def ::error-response (s/keys :req-un [::spec]))
+(s/def ::error-response (stc/spec (s/keys :req-un [::spec])))
 
-(s/def ::conflict-response (s/keys :req-un [::info]))
+(s/def ::conflict-response (stc/spec (s/keys :req-un [::info])))

--- a/src/wormbase/specs/gene.clj
+++ b/src/wormbase/specs/gene.clj
@@ -83,9 +83,9 @@
 
 (s/def ::undone (s/keys :req-un [::live ::dead]))
 
-(s/def ::kill (s/keys :opt [:provenance/why
-                            :provenance/when
-                            :provenance/who]))
+(s/def ::kill (stc/spec (s/nilable (s/keys :opt [:provenance/why
+                                                 :provenance/when
+                                                 :provenance/who]))))
 
 (s/def ::kill-response (s/keys :req-un [::killed]))
 

--- a/src/wormbase/specs/gene.clj
+++ b/src/wormbase/specs/gene.clj
@@ -3,26 +3,28 @@
             ;; for specs
             [wormbase.specs.provenance]
             [wormbase.specs.species]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [spec-tools.core :as stc]
+            [spec-tools.spec :as sts]))
 
 (def gene-id-regexp #"WBGene\d{8}")
 
-(s/def :gene/id (s/and string? (partial re-matches gene-id-regexp)))
+(s/def :gene/id (stc/spec (s/and string? (partial re-matches gene-id-regexp))))
 
-(s/def :gene/cgc-name (s/and string? not-empty))
+(s/def :gene/cgc-name (stc/spec (s/and string? not-empty)))
 
-(s/def :gene/sequence-name (s/and string? not-empty))
+(s/def :gene/sequence-name (stc/spec (s/and string? not-empty)))
 
-(s/def :gene/biotype (s/and keyword?
-                            #(= (namespace %) "biotype")))
+(s/def :gene/biotype (stc/spec (s/and keyword?
+                                      #(= (namespace %) "biotype"))))
 
-(s/def :gene/species (s/keys :req [(or :species/id :species/latin-name)]))
+(s/def :gene/species (stc/spec (s/keys :req [(or :species/id :species/latin-name)])))
 
-(s/def :gene.status/dead boolean?)
+(s/def :gene.status/dead sts/boolean?)
 
-(s/def :gene.status/live boolean?)
+(s/def :gene.status/live sts/boolean?)
 
-(s/def :gene.status/suppressed boolean?)
+(s/def :gene.status/suppressed sts/boolean?)
 
 (def all-statuses #{:gene.status/dead
                     :gene.status/live
@@ -34,48 +36,48 @@
                       :short (set (map (comp keyword name) all-statuses))
                       :qualified all-statuses))
 
-(s/def ::cloned (s/and
-                 (s/keys :req [:gene/biotype
-                               :gene/sequence-name
-                               :gene/species]
-                         :opt [:gene/cgc-name
-                               :provenance/who
-                               :provenance/how
-                               :provenance/why])))
+(s/def ::cloned (stc/spec (s/and
+                           (s/keys :req [:gene/biotype
+                                         :gene/sequence-name
+                                         :gene/species]
+                                   :opt [:gene/cgc-name
+                                         :provenance/who
+                                         :provenance/how
+                                         :provenance/why]))))
 
-(s/def ::uncloned (s/and
-                   (s/keys :req [:gene/species :gene/cgc-name]
-                           :opt [:gene/cgc-name
-                                 :provenance/who
-                                 :provenance/how
-                                 :provenance/why])))
+(s/def ::uncloned (stc/spec (s/and
+                             (s/keys :req [:gene/species :gene/cgc-name]
+                                     :opt [:gene/cgc-name
+                                           :provenance/who
+                                           :provenance/how
+                                           :provenance/why]))))
 
-(s/def ::new (s/or :cloned ::cloned
-                   :uncloned ::uncloned))
+(s/def ::new (stc/spec (s/or :cloned ::cloned
+                             :uncloned ::uncloned)))
 
-(s/def ::created (s/keys :req [:gene/id :gene/status]))
+(s/def ::created (stc/spec (s/keys :req [:gene/id :gene/status])))
 
-(s/def ::update (s/keys :opt [:gene/biotype
-                              :provenance/who
-                              :provenance/when
-                              :provenance/why]
-                        :req [:gene/species
-                              (or (or :gene/cgc-name
-                                      :gene/sequence-name)
-                                  (and :gene/cgc-name
-                                       :gene/sequence-name))]))
+(s/def ::update (stc/spec (s/keys :opt [:gene/biotype
+                                        :provenance/who
+                                        :provenance/when
+                                        :provenance/why]
+                                  :req [:gene/species
+                                        (or (or :gene/cgc-name
+                                                :gene/sequence-name)
+                                            (and :gene/cgc-name
+                                                 :gene/sequence-name))])))
 
 
-(s/def ::updated (s/keys :req [:gene/id]))
+(s/def ::updated (stc/spec (s/keys :req [:gene/id])))
 
-(s/def ::merge (s/keys :req [:gene/biotype]))
+(s/def ::merge (stc/spec (s/keys :req [:gene/biotype])))
 
-(s/def ::product (s/keys :req [:gene/sequence-name :gene/biotype]))
+(s/def ::product (stc/spec (s/keys :req [:gene/sequence-name :gene/biotype])))
 
-(s/def ::split (s/keys :req [:gene/biotype]
-                       :req-un [::product]))
+(s/def ::split (stc/spec (s/keys :req [:gene/biotype]
+                                 :req-un [::product])))
 
-(s/def ::split-response (s/keys :req-un [::updated ::created]))
+(s/def ::split-response (stc/spec (s/keys :req-un [::updated ::created])))
 
 (s/def ::live :gene/id)
 
@@ -87,14 +89,14 @@
                                                  :provenance/when
                                                  :provenance/who]))))
 
-(s/def ::kill-response (s/keys :req-un [::killed]))
+(s/def ::kill-response (stc/spec (s/keys :req-un [::killed])))
 
-(s/def ::info (s/keys :req [:gene/id
-                            :gene/species
-                            :gene/status]
-                      :opt [:gene/biotype
-                            :gene/sequence-name
-                            :gene/cgc-name]))
+(s/def ::info (stc/spec (s/keys :req [:gene/id
+                                      :gene/species
+                                      :gene/status]
+                                :opt [:gene/biotype
+                                      :gene/sequence-name
+                                      :gene/cgc-name])))
 
 (s/def ::identifier (s/or :gene/id :gene/id
                           :gene/cgc-name :gene/cgc-name
@@ -102,19 +104,19 @@
 
 (s/def ::killed ::identifier)
 
-(s/def ::find-term (s/and string?
-                          (complement str/blank?)))
+(s/def ::find-term (stc/spec (s/and string?
+                                    (complement str/blank?))))
 
 (s/def ::pattern ::find-term)
 
-(s/def ::find-request (s/keys :req-un [::pattern]))
+(s/def ::find-request (stc/spec (s/keys :req-un [::pattern])))
 
-(s/def ::find-match (s/keys :req [:gene/id]
-                            :opt [:gene/cgc-name
-                                  :gene/sequence-name]))
+(s/def ::find-match (stc/spec (s/keys :req [:gene/id]
+                                      :opt [:gene/cgc-name
+                                            :gene/sequence-name])))
 
-(s/def ::matches (s/coll-of ::find-match :kind vector?))
+(s/def ::matches (stc/spec (s/coll-of ::find-match :kind vector?)))
 
-(s/def ::find-result (s/keys :req-un [::matches]))
+(s/def ::find-result (stc/spec (s/keys :req-un [::matches])))
 
 

--- a/src/wormbase/specs/person.clj
+++ b/src/wormbase/specs/person.clj
@@ -1,47 +1,48 @@
 (ns wormbase.specs.person
   (:require
-   [clojure.spec.alpha :as s]))
+   [clojure.spec.alpha :as s]
+   [spec-tools.core :as stc]
+   [spec-tools.spec :as sts]))
 
 (def email-regexp #"[a-z0-9][a-z0-9.]+?@wormbase\.org")
 
 (def id-regexp #"^WBPerson\d{1,}")
 
-(s/def ::id (s/and string? #(re-matches id-regexp %)))
+(s/def ::id (stc/spec (s/and sts/string? #(re-matches id-regexp %))))
 
-(s/def ::name (s/and string? not-empty))
+(s/def ::name (stc/spec (s/and sts/string? not-empty)))
 
 (s/def :person/name ::name)
 
-(s/def :person/active? boolean?)
+(s/def :person/active? sts/boolean?)
 
-(s/def ::email (s/and string? #(re-matches email-regexp %)))
+(s/def ::email (stc/spec (s/and sts/string? #(re-matches email-regexp %))))
 
 (s/def :person/email ::email)
 
 (s/def :person/id ::id)
 
-(s/def ::permissions (s/coll-of ::permission :kind set? :min-count 1))
+(s/def ::permissions (stc/spec (s/coll-of ::permission
+                                          :kind sts/vector?
+                                          :min-count 1)))
 
-(s/def ::role (s/and keyword? #(= (namespace %) "person.role")))
+(s/def ::role (stc/spec (s/and sts/keyword? #(= (namespace %) "person.role"))))
 
-(s/def :role/id (s/keys :req [::role]))
+(s/def :role/id (stc/spec (s/keys :req [::role])))
 
-(s/def :person/roles (s/every ::role :into set :kind set? :distinct true))
 
-;; (s/def ::new (s/keys :req [:person/email
-;;                            :person/id]
-;;                      :opt [:person/roles]))
+(s/def :person/roles (stc/spec (s/coll-of ::role :distinct true)))
 
-(s/def ::people (s/coll-of ::person :kind vector? :min-count 1))
+(s/def ::people (stc/spec (s/coll-of ::person :kind sts/vector? :min-count 1)))
 
-(s/def ::identified (s/keys :req-un [::name :person/email]))
+(s/def ::identified (stc/spec (s/keys :req-un [::name :person/email])))
 
-(s/def ::identifier (s/or :person/email ::email
-                          :person/id ::id))
+(s/def ::identifier (stc/spec (s/or :person/email ::email
+                                    :person/id ::id)))
  
-(s/def ::person (s/keys :req [:person/email :person/id]
-                        :opt [:person/roles
-                              :person/active?
-                              :person/name]))
+(s/def ::person (stc/spec (s/keys :req [:person/email :person/id]
+                                  :opt [:person/roles
+                                        :person/active?
+                                        :person/name])))
 (s/def ::created ::person)
 

--- a/src/wormbase/specs/provenance.clj
+++ b/src/wormbase/specs/provenance.clj
@@ -3,19 +3,21 @@
    [clojure.spec.alpha :as s]
    [clojure.string :as str]
    [wormbase.specs.person] ;; for specs
-   [wormbase.specs.agent :as owsa]))
+   [wormbase.specs.agent :as owsa]
+   [spec-tools.spec :as sts]
+   [spec-tools.core :as stc]))
 
-(s/def :agent/id string?)
+(s/def :agent/id sts/string?)
 
 ;; TODO: clients should provide zoned-date-time (times in UTC)
 ;;       - db wants instants (java.utl.Date values)
 
-(s/def :provenance/when inst?)
+(s/def :provenance/when sts/inst?)
 
-(s/def :provenance/who (s/keys :req [(or :person/id :person/email)]))
+(s/def :provenance/who (stc/spec (s/keys :req [(or :person/id :person/email)])))
 
-(s/def :provenance/how (s/keys :req-un [::owsa/agent]))
+(s/def :provenance/how (stc/spec (s/keys :req-un [::owsa/agent])))
 
-(s/def :provenance/why (s/and string? (complement str/blank?)))
+(s/def :provenance/why (stc/spec (s/and sts/string? (complement str/blank?))))
 
-(s/def :provenance/merged-from (s/keys :req [:gene/id]))
+(s/def :provenance/merged-from (stc/spec (s/keys :req [:gene/id])))

--- a/src/wormbase/specs/species.clj
+++ b/src/wormbase/specs/species.clj
@@ -1,17 +1,21 @@
 (ns wormbase.specs.species
   (:require
-   [clojure.spec.alpha :as s]))
+   [clojure.spec.alpha :as s]
+   [spec-tools.core :as stc]
+   [spec-tools.spec :as sts]))
 
 (def id-regexp #"[a-z]{1}-[a-z]+$")
 
 (def latin-name-regexp #"[A-Z]{1}[a-z]+\s{1}[a-z]+$") 
 
 ;; TODO: do we need short-name now use EDN?
-(s/def ::short-name (s/and string? #(re-matches id-regexp %)))
+(s/def ::short-name (stc/spec (s/and sts/string? #(re-matches id-regexp %))))
 
-(s/def :species/id (s/and keyword?
-                          #(and (= (namespace %) "species")
-                                (re-matches id-regexp (name %)))))
+(s/def :species/id sts/keyword?)
+;; DISABLED predicate whilst attempting to resolve JSON coercion
+;; #(and (= (namespace %) "species")
+;;       (re-matches id-regexp (name %))))))
 
-(s/def :species/latin-name (s/and string? #(re-matches latin-name-regexp %)))
+(s/def :species/latin-name (stc/spec
+                            (s/and sts/string? #(re-matches latin-name-regexp %))))
 

--- a/src/wormbase/specs/template.clj
+++ b/src/wormbase/specs/template.clj
@@ -1,6 +1,7 @@
 (ns wormbase.specs.template
-  (:require [clojure.spec.alpha :as s]))
+  (:require [clojure.spec.alpha :as s]
+            [spec-tools.spec :as sts]))
 
-(s/def :template/describes keyword?)
+(s/def :template/describes sts/keyword?)
 
-(s/def :template/format string?)
+(s/def :template/format sts/string?)

--- a/test/integration/test_find_gene_by_any_name.clj
+++ b/test/integration/test_find_gene_by_any_name.clj
@@ -16,7 +16,7 @@
   (binding [fake-auth/*gapi-verify-token-response* {"email" current-user}]
     (let [current-user-token (get fake-auth/tokens current-user)
           params {:pattern pattern}
-          headers {"content-type" "application/edn"
+          headers {"content-type" "application/json"
                    "authorization" (str "Token " current-user-token)}
           [status body] (tu/get*
                          service/app
@@ -64,7 +64,7 @@
                   [status body] (find-gene valid-prefix)
                   matches (:matches body)]
               (tu/status-is? 200 status body)
-              (t/is (not (empty? matches))
+              (t/is (seq matches)
                     (str "No matches found for " valid-prefix))
               (t/is (some (fn [match] (= (:gene/id match) gid)) matches)
                     (str "Could not find any GeneID matching " gid

--- a/test/integration/test_kill_gene.clj
+++ b/test/integration/test_kill_gene.clj
@@ -31,7 +31,7 @@
           [status body] (tu/delete
                          service/app
                          (str "/gene/" gene-id)
-                         "application/edn"
+                         "application/json"
                          {"authorization" (str "Token " current-user-token)})]
       [status (tu/parse-body body)])))
 

--- a/test/integration/test_merge_genes.clj
+++ b/test/integration/test_merge_genes.clj
@@ -36,7 +36,7 @@
       :or {current-user "tester@wormbase.org"}}]
 
   (binding [fake-auth/*gapi-verify-token-response* {"email" current-user}]
-    (let [data (pr-str payload)
+    (let [data (tu/->json payload)
           uri (str "/gene/" into-id "/merge-from/" from-id)
           [status body]
           (tu/raw-put-or-post*
@@ -44,7 +44,7 @@
            uri
            :post
            data
-           "application/edn"
+           "application/json"
            {"authorization" "Token IsnotReleventHere"})]
       [status (tu/parse-body body)])))
 
@@ -55,7 +55,7 @@
     (let [current-user-token (get fake-auth/tokens current-user)]
       (tu/delete service/app
                  (str "/gene/" into-id "/merge-from/" from-id)
-                 "application/edn"
+                 "application/json"
                  {"authorization" (str "Token " current-user-token)}))))
 
 (t/deftest must-meet-spec

--- a/test/integration/test_service.clj
+++ b/test/integration/test_service.clj
@@ -13,18 +13,18 @@
   (t/testing "When no routes are matched in request processing"
     (let [response (service/app
                     {:uri "/aliens"
-                     :headers {"content-type" "application/edn"
-                               "accept" "application/edn"
+                     :headers {"content-type" "application/json"
+                               "accept" "application/json"
                                "authorization" "Token TOKEN_HERE"}
                      :query-params {}
                      :request-method :get})]
       (t/is (= 404 (:status response)))
       (t/is (str/starts-with?
              (peek (http-response/find-header response "Content-Type"))
-             "application/edn")
+             "application/json")
             (str "Wrong content-type?:" (pr-str (:headers response))))
       (t/is (contains? response :body))
-      (let [decode #(service/decode-content "application/edn" %)
+      (let [decode #(service/decode-content "application/json" %)
             response-text (some-> response :body slurp)]
         (t/is (not= nil (:reason (decode response-text)))
               (str response-text))))))

--- a/test/integration/test_update_gene.clj
+++ b/test/integration/test_update_gene.clj
@@ -74,7 +74,7 @@
                             (dissoc :gene/status)
                             (assoc :gene/cgc-name new-cgc-name)
                             (assoc :provenance/who
-                                   [:person/email "tester@wormbase.org"])
+                                   {:person/email "tester@wormbase.org"})
                             (assoc :provenance/why
                                    why))]
             (let [response (update-gene identifier payload)

--- a/test/wormbase/api_test_client.clj
+++ b/test/wormbase/api_test_client.clj
@@ -13,7 +13,7 @@
   [entity-kind data & {:keys [current-user]
                        :or {current-user default-user}}]
   (binding [fake-auth/*gapi-verify-token-response* {"email" current-user}]
-    (let [data (pr-str data)
+    (let [data (tu/->json data)
           token (get fake-auth/tokens current-user)
           [status body]
           (tu/raw-put-or-post*
@@ -21,7 +21,7 @@
            (str "/" entity-kind "/")
            :post
            data
-           "application/edn"
+           "application/json"
            {"authorization" (str "Token " token)})]
       [status (tu/parse-body body)])))
 
@@ -33,7 +33,7 @@
           put (partial tu/raw-put-or-post* service/app uri :put)
           token (get fake-auth/tokens current-user)
           headers {"authorization" (str "Token " token)}
-          [status body] (put (pr-str data) nil headers)]
+          [status body] (put (tu/->json data) "application/json" headers)]
       [status (tu/parse-body body)])))
 
 (defn info

--- a/test/wormbase/api_test_client.clj
+++ b/test/wormbase/api_test_client.clj
@@ -41,7 +41,7 @@
                              :or {current-user "tester@wormbase.org"
                                   params {}}}]
   (let [current-user-token (get fake-auth/tokens current-user)
-        headers {"content-type" "application/edn"
+        headers {"content-type" "application/json"
                  "authorization" (str "Token " current-user-token)}
         [status body] (tu/get*
                        service/app
@@ -58,5 +58,5 @@
           uri (str "/" entity-kind "/" (str/replace-first path #"^/" ""))]
       (tu/delete service/app
                  uri
-                 "application/edn"
+                 "application/json"
                  {"authorization" (str "Token " current-user-token)}))))

--- a/test/wormbase/test_utils.clj
+++ b/test/wormbase/test_utils.clj
@@ -19,6 +19,7 @@
    [wormbase.gen-specs.gene :as gsg]
    [wormbase.gen-specs.person :as gsp]
    [wormbase.gen-specs.species :as gss]
+   [wormbase.names.service :as wns]
    [wormbase.specs.gene :as owsg]
    [peridot.core :as p]
    [spec-tools.core :as stc])
@@ -54,7 +55,7 @@
   (let [body (read-body body)
         body (if (instance? String body)
                (try
-                 (muuntaja/decode mformats "application/edn" body)
+                 (muuntaja/decode mformats "application/json" body)
                  (catch ExceptionInfo exc
                    (print-decode-err exc body)
                    (throw exc)))
@@ -69,11 +70,7 @@
     (get-in spec [:definitions schema-name])))
 
 (defn edn-stream [x]
-  (try
-    (muuntaja/encode mformats "application/edn" x)
-    (catch Exception e
-      (println  "********** COULD NOT ENCODE " x "as EDN")
-      (throw e))))
+  (muuntaja/encode mformats "application/edn" x))
 
 (defn follow-redirect [state]
   (if (some-> state :response :headers (get "Location"))
@@ -346,3 +343,10 @@
 (defn person-samples [n]
   (let [data-samples (gen/sample gsp/person n)]
     data-samples))
+
+(defn ->json [data]
+  (let [formats (deref #'wns/mformats)]
+    (-> formats
+        (muuntaja/encode "application/json" data)
+        (slurp))))
+


### PR DESCRIPTION
@sibyl229 I've made the default api format to be JSON as you requested/suggested in the last db-dev meeting.

Turns out it wasn't as hard as I'd thought; mainly me misunderstanding how compojure-api's resource metadata works (`:body` vs `:body-params`) and wrapping all specs with spec-tools wrappers.

Although the tests all specify "application/json" as the default, I've tested changing this breifly and content-negotiation should work with any of the supported formats (json, transit+json and edn in this app).
