### PR TITLE
logout when fetch gets 401 error

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -18,7 +18,7 @@ class App extends Component {
     return (
       <Authenticate>
         {
-          ({isAuthenticated, user, login, profile}) => (
+          ({isAuthenticated, user, login, profile, authorizedFetch}) => (
             <div className={this.props.classes.root}>
               <Header>
                 <ProfileButton name={user.name}/>
@@ -37,16 +37,17 @@ class App extends Component {
                       <Switch>
                         <Route path={`${match.url}/new`} component={() => (
                           <DocumentTitle title={`Create a gene`}>
-                            <GeneCreate />
+                            <GeneCreate authorizedFetch={authorizedFetch} />
                           </DocumentTitle>
                         )} />
                         <Route path={`${match.url}/id/:id`} component={({match}) => (
                           <DocumentTitle title={`Gene ${match.params.id}`}>
-                            <GeneProfile wbId={match.params.id} />
+                            <GeneProfile
+                              wbId={match.params.id}
+                              authorizedFetch={authorizedFetch}
+                            />
                           </DocumentTitle>
                         )} />
-                        <Route path={`${match.url}/merge`} component={() => <Page>form to merge two genes</Page>} />
-                        <Route path={`${match.url}/split`} component={() => <Page>form to split a gene</Page>} />
                       </Switch>
                     )} />
                     <Route path="/variation" component={() => (

--- a/client/src/containers/Authenticate/Logout.js
+++ b/client/src/containers/Authenticate/Logout.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { withRouter } from 'react-router-dom';
 import { Button, withStyles } from '../../components/elements';
 
 const Logout = (props) => {
@@ -7,7 +8,10 @@ const Logout = (props) => {
     <Button
       variant="raised"
 
-      onClick={() => props.onLogout()}
+      onClick={() => {
+        props.onLogout();
+        props.history.push('/');
+      }}
     >
       Logout
     </Button>
@@ -16,6 +20,9 @@ const Logout = (props) => {
 
 Logout.propTypes = {
   onLogout: PropTypes.func.isRequired,
+  history: PropTypes.shape({
+    push: PropTypes.func.isRequired,
+  }),
 };
 
-export default Logout;
+export default withRouter(Logout);

--- a/client/src/containers/Gene/GeneCreate.js
+++ b/client/src/containers/Gene/GeneCreate.js
@@ -4,7 +4,6 @@ import { Link, withRouter } from 'react-router-dom';
 import { mockFetchOrNot } from '../../mock';
 import { withStyles, Button, Page, PageLeft, PageMain, PageRight, Icon, Typography } from '../../components/elements';
 import GeneForm from './GeneForm';
-import { authorizedFetch } from '../Authenticate';
 
 class GeneCreate extends Component {
   constructor(props) {
@@ -40,7 +39,7 @@ class GeneCreate extends Component {
         }
       },
       () => {
-        return authorizedFetch(`/api/gene/`, {
+        return this.props.authorizedFetch(`/api/gene/`, {
           method: 'POST',
           body: JSON.stringify({
             ...data
@@ -101,6 +100,7 @@ GeneCreate.propTypes = {
   history: PropTypes.shape({
     push: PropTypes.func.isRequired,
   }).isRequired,
+  authorizedFetch: PropTypes.func.isRequired,
 };
 
 export default withRouter(GeneCreate);

--- a/client/src/containers/Gene/GeneProfile.js
+++ b/client/src/containers/Gene/GeneProfile.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { mockFetchOrNot } from '../../mock';
-import { authorizedFetch } from '../Authenticate';
 import { withStyles, Button, Icon, Page, PageLeft, PageMain, PageRight, Typography } from '../../components/elements';
 import GeneForm from './GeneForm';
 import KillGeneDialog from './KillGeneDialog';
@@ -42,7 +41,7 @@ class GeneProfile extends Component {
           });
         },
         () => {
-          return authorizedFetch(`/api/gene/${this.props.wbId}`, {});
+          return fetch(`/api/gene/${this.props.wbId}`, {});
         },
       ).then((response) => response.json()).then((response) => {
         this.setState({
@@ -66,7 +65,7 @@ class GeneProfile extends Component {
           });
         },
         () => {
-          return authorizedFetch(`/api/gene/${this.props.wbId}`, {
+          return this.props.authorizedFetch(`/api/gene/${this.props.wbId}`, {
             method: 'PUT',
             body: JSON.stringify({
               ...data
@@ -219,6 +218,7 @@ class GeneProfile extends Component {
 GeneProfile.propTypes = {
   classes: PropTypes.object.isRequired,
   wbId: PropTypes.string.isRequired,
+  authorizedFetch: PropTypes.func.isRequired,
 };
 
 const styles = (theme) => ({

--- a/client/src/containers/Gene/RecentActivities.js
+++ b/client/src/containers/Gene/RecentActivities.js
@@ -12,7 +12,6 @@ import {
   TableRow,
   Timestamp,
 } from '../../components/elements';
-import { authorizedFetch } from '../Authenticate';
 
 class RecentActivities extends Component {
   constructor(props) {
@@ -79,7 +78,7 @@ class RecentActivities extends Component {
         return mockFetch.get('*', mockData);
       },
       () => {
-        return authorizedFetch(`/api/recent/gene`, {
+        return fetch(`/api/recent/gene`, {
           method: 'GET'
         });
       },


### PR DESCRIPTION
#25 client side solution to handle token expiration.
Display the login page when a fetch request returns a 401 error. Once the user logs in, the route containing the form will be shown again.

A usability problem is that the user entered form content will be overwritten when the form loads again. But I don't think this can be avoided with our current implementation that keeps the form state inside the GeneForm component. To fix it, we probably needs to track the form state in a Redux store.