### PR TITLE
Feature/undo

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -29,7 +29,7 @@ class App extends Component {
                       <Route exact path="/" component={() => <Redirect to="/gene" /> } />
                       <Route exact path="/gene" component={() => (
                         <DocumentTitle title="Gene index">
-                          <Gene />
+                          <Gene authorizedFetch={authorizedFetch} />
                         </DocumentTitle>
                       )} />
                       <Route path="/gene" component={({match}) => (

--- a/client/src/containers/Gene/GeneActivitiesTable.js
+++ b/client/src/containers/Gene/GeneActivitiesTable.js
@@ -26,9 +26,9 @@ class GeneActivitiesTable extends Component {
     };
   }
 
-  openResurrectGeneDialog = (activityIndex) => {
+  openDialog = (dialogKey, activityIndex) => {
     this.setState({
-      showDialog: RESURRECT,
+      showDialog: dialogKey,
       selectedActivityIndex: activityIndex,
     });
   }
@@ -46,7 +46,7 @@ class GeneActivitiesTable extends Component {
         {
           eventType === 'kill' ?
             <Button
-              onClick={() => this.openResurrectGeneDialog(activityIndex)}
+              onClick={() => this.openDialog(RESURRECT, activityIndex)}
               color="primary"
             >Resurrect</Button> :
             null

--- a/client/src/containers/Gene/GeneActivitiesTable.js
+++ b/client/src/containers/Gene/GeneActivitiesTable.js
@@ -1,0 +1,89 @@
+import React, { Component } from 'react';
+import { mockFetchOrNot } from '../../mock';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import {
+  withStyles,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Timestamp,
+} from '../../components/elements';
+
+class GeneActivitiesTable extends Component {
+  render() {
+    const {classes} = this.props;
+    return (
+      <Table classes={{root: classes.root}}>
+        <TableHead>
+          <TableRow>
+            <TableCell>Time</TableCell>
+            <TableCell>Event type</TableCell>
+            <TableCell className={classes.entityColumnHeader}>Entity</TableCell>
+            <TableCell>Related entity</TableCell>
+            <TableCell>Curated by</TableCell>
+            <TableCell>Reason</TableCell>
+            <TableCell>Agent</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {
+            this.props.activities.map(
+              (historyItem) => {
+                return (
+                  <TableRow>
+                    <TableCell className={classes.time}>
+                      <Timestamp time={historyItem.time}/>
+                    </TableCell>
+                    <TableCell>{historyItem.eventType}</TableCell>
+                    <TableCell className={classes.entityCell}>
+                      {
+                        historyItem.entity ?
+                          <Link to={`/gene/id/${historyItem.entity.id}`}>{historyItem.entity.label}</Link> :
+                          null
+                      }
+                    </TableCell>
+                    <TableCell>
+                      {
+                        historyItem.relatedEntity ?
+                          <Link to={`/gene/id/${historyItem.relatedEntity.id}`}>{historyItem.relatedEntity.label}</Link> :
+                          null
+                      }
+                    </TableCell>
+                    <TableCell>{historyItem.curatedBy.name}</TableCell>
+                    <TableCell>{historyItem.reason}</TableCell>
+                    <TableCell>{historyItem.agent}</TableCell>
+                  </TableRow>
+                )
+              }
+            )
+          }
+        </TableBody>
+      </Table>
+    );
+  }
+}
+
+GeneActivitiesTable.propTypes = {
+  classes: PropTypes.object.isRequired,
+  activities: PropTypes.array,
+};
+
+GeneActivitiesTable.defaultProps = {
+  GeneActivitiesTable: [],
+};
+
+const styles = (theme) => ({
+  root: {
+    // width: 'initial',
+  },
+  time: {
+    whiteSpace: 'nowrap',
+  },
+  entityColumnHeader: {},
+  entityCell: {},
+});
+
+export default withStyles(styles)(GeneActivitiesTable);

--- a/client/src/containers/Gene/GeneActivitiesTable.js
+++ b/client/src/containers/Gene/GeneActivitiesTable.js
@@ -13,6 +13,7 @@ import {
 } from '../../components/elements';
 import ResurrectGeneDialog from './ResurrectGeneDialog';
 import UndoMergeGeneDialog from './UndoMergeGeneDialog';
+import UndoSplitGeneDialog from './UndoSplitGeneDialog';
 
 const RESURRECT = 'RESURRECT';
 const UNDO_MERGE = 'UNDO_MERGE';
@@ -49,7 +50,7 @@ class GeneActivitiesTable extends Component {
             <Button
               onClick={() => this.openDialog(RESURRECT, activityIndex)}
               color="primary"
-            >Resurrect</Button> :
+            >Undo</Button> :
             null
         }
         {
@@ -144,11 +145,24 @@ class GeneActivitiesTable extends Component {
           />
           <UndoMergeGeneDialog
             geneName={selectedActivity && selectedActivity.entity.label}
-            geneNameMergeInto={selectedActivity && selectedActivity.relatedEntity.label}
+            geneFromName={selectedActivity && selectedActivity.relatedEntity.label}
             wbId={selectedActivity && selectedActivity.entity.id}
-            wbIdMergeInto={selectedActivity && selectedActivity.relatedEntity.id}
+            wbFromId={selectedActivity && selectedActivity.relatedEntity.id}
             authorizedFetch={this.props.authorizedFetch}
             open={this.state.showDialog === UNDO_MERGE}
+            onClose={this.closeDialog}
+            onSubmitSuccess={(data) => {
+              this.closeDialog();
+              onUpdate && onUpdate();
+            }}
+          />
+          <UndoSplitGeneDialog
+            geneName={selectedActivity && selectedActivity.entity.label}
+            geneIntoName={selectedActivity && selectedActivity.relatedEntity.label}
+            wbId={selectedActivity && selectedActivity.entity.id}
+            wbIntoId={selectedActivity && selectedActivity.relatedEntity.id}
+            authorizedFetch={this.props.authorizedFetch}
+            open={this.state.showDialog === UNDO_SPLIT}
             onClose={this.closeDialog}
             onSubmitSuccess={(data) => {
               this.closeDialog();

--- a/client/src/containers/Gene/GeneActivitiesTable.js
+++ b/client/src/containers/Gene/GeneActivitiesTable.js
@@ -12,6 +12,7 @@ import {
   Timestamp,
 } from '../../components/elements';
 import ResurrectGeneDialog from './ResurrectGeneDialog';
+import UndoMergeGeneDialog from './UndoMergeGeneDialog';
 
 const RESURRECT = 'RESURRECT';
 const UNDO_MERGE = 'UNDO_MERGE';
@@ -49,6 +50,22 @@ class GeneActivitiesTable extends Component {
               onClick={() => this.openDialog(RESURRECT, activityIndex)}
               color="primary"
             >Resurrect</Button> :
+            null
+        }
+        {
+          eventType === 'split' ?
+            <Button
+              onClick={() => this.openDialog(UNDO_SPLIT, activityIndex)}
+              color="primary"
+            >Undo</Button> :
+            null
+        }
+        {
+          eventType === 'merge' ?
+            <Button
+              onClick={() => this.openDialog(UNDO_MERGE, activityIndex)}
+              color="primary"
+            >Undo</Button> :
             null
         }
       </div>
@@ -121,7 +138,20 @@ class GeneActivitiesTable extends Component {
             open={this.state.showDialog === RESURRECT}
             onClose={this.closeDialog}
             onSubmitSuccess={(data) => {
-              this.closeResurrectGeneDialog();
+              this.closeDialog();
+              onUpdate && onUpdate();
+            }}
+          />
+          <UndoMergeGeneDialog
+            geneName={selectedActivity && selectedActivity.entity.label}
+            geneNameMergeInto={selectedActivity && selectedActivity.relatedEntity.label}
+            wbId={selectedActivity && selectedActivity.entity.id}
+            wbIdMergeInto={selectedActivity && selectedActivity.relatedEntity.id}
+            authorizedFetch={this.props.authorizedFetch}
+            open={this.state.showDialog === UNDO_MERGE}
+            onClose={this.closeDialog}
+            onSubmitSuccess={(data) => {
+              this.closeDialog();
               onUpdate && onUpdate();
             }}
           />

--- a/client/src/containers/Gene/GeneActivitiesTable.js
+++ b/client/src/containers/Gene/GeneActivitiesTable.js
@@ -54,7 +54,7 @@ class GeneActivitiesTable extends Component {
             null
         }
         {
-          eventType === 'split' ?
+          eventType === 'split_into' || eventType === 'split_from' ?
             <Button
               onClick={() => this.openDialog(UNDO_SPLIT, activityIndex)}
               color="primary"
@@ -62,7 +62,7 @@ class GeneActivitiesTable extends Component {
             null
         }
         {
-          eventType === 'merge' ?
+          eventType === 'merge_into' || eventType === 'acquire_merge' ?
             <Button
               onClick={() => this.openDialog(UNDO_MERGE, activityIndex)}
               color="primary"
@@ -77,6 +77,22 @@ class GeneActivitiesTable extends Component {
     const {classes, activities, onUpdate} = this.props;
     const {selectedActivityIndex} = this.state;
     const selectedActivity = selectedActivityIndex !== null ? activities[selectedActivityIndex] : null;
+    let selectedActivityEntityKept, selectedActivityEntityOther;
+    if (selectedActivity) {
+      if (
+        selectedActivity.eventType === 'split_into' ||
+        selectedActivity.eventType === 'acquire_merge'
+      ) {
+        selectedActivityEntityKept = selectedActivity.entity;
+        selectedActivityEntityOther = selectedActivity.relatedEntity;
+      } else if (
+        selectedActivity.eventType === 'split_from' ||
+        selectedActivity.eventType === 'merge_into'
+      ) {
+        selectedActivityEntityKept = selectedActivity.relatedEntity;
+        selectedActivityEntityOther = selectedActivity.entity;
+      }
+    }
 
     return (
       <div>
@@ -144,10 +160,10 @@ class GeneActivitiesTable extends Component {
             }}
           />
           <UndoMergeGeneDialog
-            geneName={selectedActivity && selectedActivity.entity.label}
-            geneFromName={selectedActivity && selectedActivity.relatedEntity.label}
-            wbId={selectedActivity && selectedActivity.entity.id}
-            wbFromId={selectedActivity && selectedActivity.relatedEntity.id}
+            geneName={selectedActivityEntityKept && selectedActivityEntityKept.label}
+            geneFromName={selectedActivityEntityOther && selectedActivityEntityOther.label}
+            wbId={selectedActivityEntityKept && selectedActivityEntityKept.id}
+            wbFromId={selectedActivityEntityOther && selectedActivityEntityOther.id}
             authorizedFetch={this.props.authorizedFetch}
             open={this.state.showDialog === UNDO_MERGE}
             onClose={this.closeDialog}
@@ -157,10 +173,10 @@ class GeneActivitiesTable extends Component {
             }}
           />
           <UndoSplitGeneDialog
-            geneName={selectedActivity && selectedActivity.entity.label}
-            geneIntoName={selectedActivity && selectedActivity.relatedEntity.label}
-            wbId={selectedActivity && selectedActivity.entity.id}
-            wbIntoId={selectedActivity && selectedActivity.relatedEntity.id}
+            geneName={selectedActivityEntityKept && selectedActivityEntityKept.label}
+            geneIntoName={selectedActivityEntityOther && selectedActivityEntityOther.label}
+            wbId={selectedActivityEntityKept && selectedActivityEntityKept.id}
+            wbIntoId={selectedActivityEntityOther && selectedActivityEntityOther.id}
             authorizedFetch={this.props.authorizedFetch}
             open={this.state.showDialog === UNDO_SPLIT}
             onClose={this.closeDialog}

--- a/client/src/containers/Gene/GeneActivitiesTable.js
+++ b/client/src/containers/Gene/GeneActivitiesTable.js
@@ -100,8 +100,8 @@ class GeneActivitiesTable extends Component {
           <TableHead>
             <TableRow>
               <TableCell>Time</TableCell>
-              <TableCell>Event type</TableCell>
               <TableCell className={classes.entityColumnHeader}>Entity</TableCell>
+              <TableCell>Event type</TableCell>
               <TableCell>Related entity</TableCell>
               <TableCell>Curated by</TableCell>
               <TableCell>Reason</TableCell>
@@ -118,7 +118,6 @@ class GeneActivitiesTable extends Component {
                       <TableCell className={classes.time}>
                         <Timestamp time={activityItem.time}/>
                       </TableCell>
-                      <TableCell>{activityItem.eventType}</TableCell>
                       <TableCell className={classes.entityCell}>
                         {
                           activityItem.entity ?
@@ -126,6 +125,7 @@ class GeneActivitiesTable extends Component {
                             null
                         }
                       </TableCell>
+                      <TableCell>{activityItem.eventType}</TableCell>
                       <TableCell>
                         {
                           activityItem.relatedEntity ?

--- a/client/src/containers/Gene/GeneActivitiesTable.js
+++ b/client/src/containers/Gene/GeneActivitiesTable.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import { mockFetchOrNot } from '../../mock';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import {

--- a/client/src/containers/Gene/GeneProfile.js
+++ b/client/src/containers/Gene/GeneProfile.js
@@ -224,7 +224,10 @@ class GeneProfile extends Component {
           <div className={classes.section}>
             <Typography variant="title" gutterBottom>Change history</Typography>
             <div className={classes.historyTable}>
-              <RecentActivitiesSingleGene wbId={this.props.wbId} />
+              <RecentActivitiesSingleGene
+                wbId={this.props.wbId}
+                authorizedFetch={this.props.authorizedFetch}
+              />
             </div>
           </div>
         </PageMain>

--- a/client/src/containers/Gene/GeneProfile.js
+++ b/client/src/containers/Gene/GeneProfile.js
@@ -16,6 +16,7 @@ import {
 } from '../../components/elements';
 import GeneForm from './GeneForm';
 import KillGeneDialog from './KillGeneDialog';
+import ResurrectGeneDialog from './ResurrectGeneDialog';
 import MergeGeneDialog from './MergeGeneDialog';
 import SplitGeneDialog from './SplitGeneDialog';
 import RecentActivitiesSingleGene from './RecentActivitiesSingleGene';
@@ -29,6 +30,7 @@ class GeneProfile extends Component {
       successMessage: null,
       data: {},
       showKillGeneDialog: false,
+      showResurrectGeneDialog: false,
       showMergeGeneDialog: false,
       showSplitGeneDialog: false,
     };
@@ -129,6 +131,18 @@ class GeneProfile extends Component {
     });
   }
 
+  openResurrectGeneDialog = () => {
+    this.setState({
+      showResurrectGeneDialog: true,
+    });
+  }
+
+  closeResurrectGeneDialog = () => {
+    this.setState({
+      showResurrectGeneDialog: false,
+    });
+  }
+
   openMergeGeneDialog = () => {
     this.setState({
       showMergeGeneDialog: true,
@@ -216,8 +230,7 @@ class GeneProfile extends Component {
         </PageMain>
         <PageRight>
           {
-            this.state.data['gene/status'] !== 'gene.status/live' ?
-              null :
+            this.state.data['gene/status'] === 'gene.status/live' ?
               <div className={classes.operations}>
                 <Button
                   variant="raised"
@@ -232,6 +245,13 @@ class GeneProfile extends Component {
                   variant="raised"
                   onClick={this.openKillGeneDialog}
                 >Kill Gene</Button>
+              </div> :
+              <div className={classes.operations}>
+                <Button
+                  className={classes.killButton}
+                  variant="raised"
+                  onClick={this.openResurrectGeneDialog}
+                >Resurrect Gene</Button>
               </div>
           }
         </PageRight>
@@ -244,6 +264,23 @@ class GeneProfile extends Component {
           onSubmitSuccess={(data) => {
             this.fetchData();
             this.closeKillGeneDialog();
+          }}
+        />
+        <ResurrectGeneDialog
+          geneName={this.getDisplayName(this.state.data)}
+          wbId={this.state.data['gene/id']}
+          authorizedFetch={this.props.authorizedFetch}
+          open={this.state.showResurrectGeneDialog}
+          onClose={this.closeResurrectGeneDialog}
+          onSubmitSuccess={(data) => {
+            this.setState((prevState) => ({
+              data: {
+                ...prevState.data,
+                'gene/status': 'gene.status/live',
+              },
+            }), () => {
+              this.closeResurrectGeneDialog();
+            });
           }}
         />
         <MergeGeneDialog

--- a/client/src/containers/Gene/MergeGeneDialog.js
+++ b/client/src/containers/Gene/MergeGeneDialog.js
@@ -95,10 +95,6 @@ MergeGeneDialog.propTypes = {
   wbId: PropTypes.string.isRequired,
   geneName: PropTypes.string.isRequired,
   authorizedFetch: PropTypes.func.isRequired,
-  open: PropTypes.bool,
-  onClose: PropTypes.func,
-  onSubmitSuccess: PropTypes.func,
-  onSubmitError: PropTypes.func,
 };
 
 const styles = (theme) => ({

--- a/client/src/containers/Gene/RecentActivities.js
+++ b/client/src/containers/Gene/RecentActivities.js
@@ -11,6 +11,7 @@ import {
   TableRow,
   Timestamp,
 } from '../../components/elements';
+import GeneActivitiesTable from './GeneActivitiesTable';
 
 class RecentActivities extends Component {
   constructor(props) {
@@ -81,6 +82,7 @@ class RecentActivities extends Component {
           method: 'GET'
         });
       },
+      true
     ).then((response) => response.json()).then((data) => {
       this.setState({
         data: data.reason ? [] : data,
@@ -92,52 +94,7 @@ class RecentActivities extends Component {
   render() {
     const {classes} = this.props;
     return (
-      <Table classes={{root: classes.root}}>
-        <TableHead>
-          <TableRow>
-            <TableCell>Time</TableCell>
-            <TableCell>Event type</TableCell>
-            <TableCell>Entity</TableCell>
-            <TableCell>Related entity</TableCell>
-            <TableCell>Curated by</TableCell>
-            <TableCell>Reason</TableCell>
-            <TableCell>Agent</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {
-            this.state.data.map(
-              (historyItem) => {
-                return (
-                  <TableRow>
-                    <TableCell className={classes.time}>
-                      <Timestamp time={historyItem.time} />
-                    </TableCell>
-                    <TableCell>{historyItem.eventType}</TableCell>
-                    <TableCell>
-                      {
-                        historyItem.entity ?
-                          <Link to={`/gene/id/${historyItem.entity.id}`}>{historyItem.entity.label}</Link> :
-                          null
-                      }
-                    </TableCell>
-                    <TableCell>
-                      {
-                        historyItem.relatedEntity ?
-                          <Link to={`/gene/id/${historyItem.relatedEntity.id}`}>{historyItem.relatedEntity.label}</Link> :
-                          null
-                      }
-                    </TableCell>
-                    <TableCell>{historyItem.curatedBy.name}</TableCell>
-                    <TableCell>{historyItem.reason}</TableCell>
-                    <TableCell>{historyItem.agent}</TableCell>
-                  </TableRow>
-                )
-              }
-            )
-          }
-        </TableBody>
-      </Table>
+      <GeneActivitiesTable activities={this.state.data} />
     );
   }
 }

--- a/client/src/containers/Gene/RecentActivities.js
+++ b/client/src/containers/Gene/RecentActivities.js
@@ -92,15 +92,20 @@ class RecentActivities extends Component {
   }
 
   render() {
-    const {classes} = this.props;
+    const {classes, authorizedFetch} = this.props;
     return (
-      <GeneActivitiesTable activities={this.state.data} />
+      <GeneActivitiesTable
+        activities={this.state.data}
+        authorizedFetch={authorizedFetch}
+        onUpdate={this.fetchData}
+      />
     );
   }
 }
 
 RecentActivities.propTypes = {
   wbId: PropTypes.string.isRequired,
+  authorizedFetch: PropTypes.func,
 };
 
 const styles = (theme) => ({

--- a/client/src/containers/Gene/RecentActivities.js
+++ b/client/src/containers/Gene/RecentActivities.js
@@ -32,7 +32,7 @@ class RecentActivities extends Component {
             curatedBy: {
               name: 'Gary'
             },
-            time: '2015-08-19T23:15:30.000Z',
+            time: '2018-08-09T23:15:30.000Z',
             agent: 'script',
             reason: 'Don\'t like it',
           },
@@ -49,7 +49,7 @@ class RecentActivities extends Component {
             curatedBy: {
               name: 'Gary'
             },
-            time: '2015-08-19T23:15:30.000Z',
+            time: '2018-08-09T23:15:30.000Z',
             agent: 'script',
             reason: 'Don\'t like it',
           },
@@ -63,7 +63,7 @@ class RecentActivities extends Component {
             curatedBy: {
               name: 'Gary'
             },
-            time: '2015-08-19T23:15:30.000Z',
+            time: '2018-08-09T23:15:30.000Z',
             agent: 'script',
             reason: 'Don\'t like it',
           },
@@ -80,7 +80,7 @@ class RecentActivities extends Component {
             curatedBy: {
               name: 'Gary'
             },
-            time: '2015-08-19T23:15:30.000Z',
+            time: '2018-08-09T23:15:30.000Z',
             agent: 'script',
             reason: 'Don\'t like it',
           },
@@ -97,7 +97,7 @@ class RecentActivities extends Component {
             curatedBy: {
               name: 'Gary'
             },
-            time: '2015-08-19T23:15:30.000Z',
+            time: '2018-08-09T23:15:30.000Z',
             agent: 'script',
             reason: 'Don\'t like it',
           },
@@ -111,7 +111,7 @@ class RecentActivities extends Component {
             curatedBy: {
               name: 'Michael'
             },
-            time: '2015-07-20T23:15:30.000Z',
+            time: '2018-07-20T23:15:30.000Z',
             agent: 'web form',
             reason: 'Looked funny',
           },

--- a/client/src/containers/Gene/RecentActivities.js
+++ b/client/src/containers/Gene/RecentActivities.js
@@ -21,6 +21,37 @@ class RecentActivities extends Component {
         const mockData = [
           {
             entity: {
+              id: 'WB333',
+              label: 'aaa-22',
+            },
+            relatedEntity: {
+              id: 'WB345',
+              label: 'aaa-222'
+            },
+            eventType: 'merge',
+            curatedBy: {
+              name: 'Gary'
+            },
+            time: '2015-08-19T23:15:30.000Z',
+            agent: 'script',
+            reason: 'Don\'t like it',
+          },
+          {
+            entity: {
+              id: 'WB4',
+              label: 'aaa-3',
+            },
+            relatedEntity: null,
+            eventType: 'kill',
+            curatedBy: {
+              name: 'Gary'
+            },
+            time: '2015-08-19T23:15:30.000Z',
+            agent: 'script',
+            reason: 'Don\'t like it',
+          },
+          {
+            entity: {
               id: 'WB1',
               label: 'ab',
             },

--- a/client/src/containers/Gene/RecentActivities.js
+++ b/client/src/containers/Gene/RecentActivities.js
@@ -28,7 +28,24 @@ class RecentActivities extends Component {
               id: 'WB345',
               label: 'aaa-222'
             },
-            eventType: 'merge',
+            eventType: 'acquire_merge',
+            curatedBy: {
+              name: 'Gary'
+            },
+            time: '2015-08-19T23:15:30.000Z',
+            agent: 'script',
+            reason: 'Don\'t like it',
+          },
+          {
+            entity: {
+              id: 'WB345',
+              label: 'aaa-222'
+            },
+            relatedEntity: {
+              id: 'WB333',
+              label: 'aaa-22',
+            },
+            eventType: 'merge_into',
             curatedBy: {
               name: 'Gary'
             },
@@ -59,7 +76,24 @@ class RecentActivities extends Component {
               id: 'WB345',
               label: 'abc-1'
             },
-            eventType: 'split',
+            eventType: 'split_from',
+            curatedBy: {
+              name: 'Gary'
+            },
+            time: '2015-08-19T23:15:30.000Z',
+            agent: 'script',
+            reason: 'Don\'t like it',
+          },
+          {
+            entity: {
+              id: 'WB345',
+              label: 'abc-1'
+            },
+            relatedEntity: {
+              id: 'WB1',
+              label: 'ab',
+            },
+            eventType: 'split_into',
             curatedBy: {
               name: 'Gary'
             },
@@ -113,7 +147,7 @@ class RecentActivities extends Component {
   }
 
   render() {
-    const {classes, authorizedFetch} = this.props;
+    const {authorizedFetch} = this.props;
     return (
       <GeneActivitiesTable
         activities={this.state.data}

--- a/client/src/containers/Gene/RecentActivities.js
+++ b/client/src/containers/Gene/RecentActivities.js
@@ -1,16 +1,6 @@
 import React, { Component } from 'react';
 import { mockFetchOrNot } from '../../mock';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
-import {
-  withStyles,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableRow,
-  Timestamp,
-} from '../../components/elements';
 import GeneActivitiesTable from './GeneActivitiesTable';
 
 class RecentActivities extends Component {
@@ -108,13 +98,4 @@ RecentActivities.propTypes = {
   authorizedFetch: PropTypes.func,
 };
 
-const styles = (theme) => ({
-  root: {
-    // width: 'initial',
-  },
-  time: {
-    whiteSpace: 'nowrap',
-  }
-});
-
-export default withStyles(styles)(RecentActivities);
+export default RecentActivities;

--- a/client/src/containers/Gene/RecentActivitiesSingleGene.js
+++ b/client/src/containers/Gene/RecentActivitiesSingleGene.js
@@ -35,7 +35,7 @@ class RecentActivitiesSingleGene extends Component {
               id: 'WB345',
               label: 'abc-1'
             },
-            eventType: 'split',
+            eventType: 'split_from',
             curatedBy: {
               name: 'Gary'
             },

--- a/client/src/containers/Gene/RecentActivitiesSingleGene.js
+++ b/client/src/containers/Gene/RecentActivitiesSingleGene.js
@@ -30,6 +30,16 @@ class RecentActivitiesSingleGene extends Component {
       (mockFetch) => {
         const mockData = [
           {
+            relatedEntity: null,
+            eventType: 'kill',
+            curatedBy: {
+              name: 'Gary'
+            },
+            time: '2015-08-19T23:15:30.000Z',
+            agent: 'script',
+            reason: 'Don\'t like it',
+          },
+          {
             relatedEntity: {
               id: 'WB345',
               label: 'abc-1'
@@ -62,7 +72,13 @@ class RecentActivitiesSingleGene extends Component {
             agent: 'script',
             reason: 'New',
           },
-        ];
+        ].map((activityItem) => ({
+          ...activityItem,
+          entity: {
+            id: this.props.wbId,
+            label: this.props.wbId,
+          },
+        }))
         return mockFetch.get('*', mockData);
       },
       () => {
@@ -80,10 +96,12 @@ class RecentActivitiesSingleGene extends Component {
   }
 
   render() {
-    const {classes} = this.props;
+    const {classes, authorizedFetch} = this.props;
     return (
       <GeneActivitiesTable
         activities={this.state.data}
+        authorizedFetch={authorizedFetch}
+        onUpdate={this.fetchData}
         classes={{
           entityCell: classes.entityCell,
           entityColumnHeader: classes.entityColumnHeader,
@@ -95,6 +113,7 @@ class RecentActivitiesSingleGene extends Component {
 
 RecentActivitiesSingleGene.propTypes = {
   wbId: PropTypes.string.isRequired,
+  authorizedFetch: PropTypes.func,
 };
 
 const styles = (theme) => ({

--- a/client/src/containers/Gene/RecentActivitiesSingleGene.js
+++ b/client/src/containers/Gene/RecentActivitiesSingleGene.js
@@ -1,16 +1,7 @@
 import React, { Component } from 'react';
 import { mockFetchOrNot } from '../../mock';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
-import {
-  withStyles,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableRow,
-  Timestamp,
-} from '../../components/elements';
+import { withStyles } from '../../components/elements';
 import GeneActivitiesTable from './GeneActivitiesTable';
 
 class RecentActivitiesSingleGene extends Component {
@@ -117,12 +108,6 @@ RecentActivitiesSingleGene.propTypes = {
 };
 
 const styles = (theme) => ({
-  root: {
-    // width: 'initial',
-  },
-  time: {
-    whiteSpace: 'nowrap',
-  },
   entityColumnHeader: {
     display: 'none',
   },

--- a/client/src/containers/Gene/RecentActivitiesSingleGene.js
+++ b/client/src/containers/Gene/RecentActivitiesSingleGene.js
@@ -26,7 +26,7 @@ class RecentActivitiesSingleGene extends Component {
             curatedBy: {
               name: 'Gary'
             },
-            time: '2015-08-19T23:15:30.000Z',
+            time: '2018-08-09T23:15:30.000Z',
             agent: 'script',
             reason: 'Don\'t like it',
           },
@@ -39,7 +39,7 @@ class RecentActivitiesSingleGene extends Component {
             curatedBy: {
               name: 'Gary'
             },
-            time: '2015-08-19T23:15:30.000Z',
+            time: '2018-08-09T23:15:30.000Z',
             agent: 'script',
             reason: 'Don\'t like it',
           },

--- a/client/src/containers/Gene/RecentActivitiesSingleGene.js
+++ b/client/src/containers/Gene/RecentActivitiesSingleGene.js
@@ -11,6 +11,7 @@ import {
   TableRow,
   Timestamp,
 } from '../../components/elements';
+import GeneActivitiesTable from './GeneActivitiesTable';
 
 class RecentActivitiesSingleGene extends Component {
   constructor(props) {
@@ -69,6 +70,7 @@ class RecentActivitiesSingleGene extends Component {
           method: 'GET'
         });
       },
+      true,
     ).then((response) => response.json()).then((data) => {
       this.setState({
         data: data.reason ? [] : data,
@@ -80,44 +82,13 @@ class RecentActivitiesSingleGene extends Component {
   render() {
     const {classes} = this.props;
     return (
-      <Table classes={{root: classes.root}}>
-        <TableHead>
-          <TableRow>
-            <TableCell>Time</TableCell>
-            <TableCell>Event type</TableCell>
-            <TableCell>Related entity</TableCell>
-            <TableCell>Curated by</TableCell>
-            <TableCell>Reason</TableCell>
-            <TableCell>Agent</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {
-            this.state.data.map(
-              (historyItem) => {
-                return (
-                  <TableRow>
-                    <TableCell className={classes.time}>
-                      <Timestamp time={historyItem.time}/>
-                    </TableCell>
-                    <TableCell>{historyItem.eventType}</TableCell>
-                    <TableCell>
-                      {
-                        historyItem.relatedEntity ?
-                          <Link to={`/gene/id/${historyItem.relatedEntity.id}`}>{historyItem.relatedEntity.label}</Link> :
-                          null
-                      }
-                    </TableCell>
-                    <TableCell>{historyItem.curatedBy.name}</TableCell>
-                    <TableCell>{historyItem.reason}</TableCell>
-                    <TableCell>{historyItem.agent}</TableCell>
-                  </TableRow>
-                )
-              }
-            )
-          }
-        </TableBody>
-      </Table>
+      <GeneActivitiesTable
+        activities={this.state.data}
+        classes={{
+          entityCell: classes.entityCell,
+          entityColumnHeader: classes.entityColumnHeader,
+        }}
+      />
     );
   }
 }
@@ -132,6 +103,12 @@ const styles = (theme) => ({
   },
   time: {
     whiteSpace: 'nowrap',
+  },
+  entityColumnHeader: {
+    display: 'none',
+  },
+  entityCell: {
+    display: 'none',
   },
 });
 

--- a/client/src/containers/Gene/ResurrectGeneDialog.js
+++ b/client/src/containers/Gene/ResurrectGeneDialog.js
@@ -67,13 +67,9 @@ class ResurrectGeneDialog extends Component {
 }
 
 ResurrectGeneDialog.propTypes = {
-  geneName: PropTypes.string,
-  wbId: PropTypes.string,
+  geneName: PropTypes.string.isRequired,
+  wbId: PropTypes.string.isRequired,
   authorizedFetch: PropTypes.func.isRequired,
-  open: PropTypes.bool,
-  onClose: PropTypes.func,
-  onSubmitSuccess: PropTypes.func,
-  onSubmitError: PropTypes.func,
 };
 
 const styles = (theme) => ({

--- a/client/src/containers/Gene/ResurrectGeneDialog.js
+++ b/client/src/containers/Gene/ResurrectGeneDialog.js
@@ -67,8 +67,8 @@ class ResurrectGeneDialog extends Component {
 }
 
 ResurrectGeneDialog.propTypes = {
-  geneName: PropTypes.string.isRequired,
-  wbId: PropTypes.string.isRequired,
+  geneName: PropTypes.string,
+  wbId: PropTypes.string,
   authorizedFetch: PropTypes.func.isRequired,
   open: PropTypes.bool,
   onClose: PropTypes.func,

--- a/client/src/containers/Gene/ResurrectGeneDialog.js
+++ b/client/src/containers/Gene/ResurrectGeneDialog.js
@@ -1,0 +1,86 @@
+import React, { Component } from 'react';
+import { mockFetchOrNot } from '../../mock';
+import PropTypes from 'prop-types';
+import {
+  withStyles,
+  AjaxDialog,
+  DialogContent,
+  DialogContentText,
+  ProgressButton,
+  TextField,
+  Typography,
+} from '../../components/elements';
+
+class ResurrectGeneDialog extends Component {
+
+  submitData = (data) => {
+    return mockFetchOrNot(
+      (mockFetch) => {
+        return mockFetch.post('*', {
+          "updated": {
+            "gene/id": this.props.wbId,
+          }
+        });
+      },
+      () => {
+        return this.props.authorizedFetch(`/api/gene/${this.props.wbId}/resurrect`, {
+          method: 'POST',
+        });
+      },
+    );
+  }
+
+  render() {
+    const {wbId, geneName, authorizedFetch, ...otherProps} = this.props;
+    return (
+      <AjaxDialog
+        title="Resurrect gene"
+        submitter={this.submitData}
+        renderSubmitButton={(props) => (
+          <ProgressButton {...props}>Resurrect {geneName}</ProgressButton>
+        )}
+        {...otherProps}>
+        {
+          ({withFieldData, errorMessage}) => {
+            const ReasonField = withFieldData(TextField, 'provenance/why');
+            return (
+              <DialogContent>
+                <DialogContentText>
+                  Gene <strong>{geneName}</strong> will be resurrected. Are you sure?
+                </DialogContentText>
+                <DialogContentText>
+                  <Typography color="error">{errorMessage}</Typography>
+                </DialogContentText>
+                <ReasonField
+                  label="Reason"
+                  helperText="Enter the reason for killing the gene"
+                  required
+                  fullWidth
+                />
+              </DialogContent>
+            )
+          }
+        }
+      </AjaxDialog>
+    );
+  }
+}
+
+ResurrectGeneDialog.propTypes = {
+  geneName: PropTypes.string.isRequired,
+  wbId: PropTypes.string.isRequired,
+  authorizedFetch: PropTypes.func.isRequired,
+  open: PropTypes.bool,
+  onClose: PropTypes.func,
+  onSubmitSuccess: PropTypes.func,
+  onSubmitError: PropTypes.func,
+};
+
+const styles = (theme) => ({
+  ResurrectButton: {
+    color: theme.palette.error.main,
+    textTransform: 'inherit',
+  },
+});
+
+export default withStyles(styles)(ResurrectGeneDialog);

--- a/client/src/containers/Gene/UndoMergeGeneDialog.js
+++ b/client/src/containers/Gene/UndoMergeGeneDialog.js
@@ -36,7 +36,7 @@ class UndoMergeGeneDialog extends Component {
         title="Undo gene merge"
         submitter={this.submitData}
         renderSubmitButton={(props) => (
-          <ProgressButton {...props}>Split {geneFromName}</ProgressButton>
+          <ProgressButton {...props}>Split {geneName}</ProgressButton>
         )}
         {...otherProps}>
         {
@@ -45,7 +45,7 @@ class UndoMergeGeneDialog extends Component {
             return (
               <DialogContent>
                 <DialogContentText>
-                  Gene <strong>{geneName}</strong> will be split from <strong>{geneFromName}</strong>.
+                  Gene <strong>{geneFromName}</strong> will be split from <strong>{geneName}</strong>.
                   Are you sure?
                 </DialogContentText>
                 <DialogContentText>

--- a/client/src/containers/Gene/UndoMergeGeneDialog.js
+++ b/client/src/containers/Gene/UndoMergeGeneDialog.js
@@ -1,0 +1,84 @@
+import React, { Component } from 'react';
+import { mockFetchOrNot } from '../../mock';
+import PropTypes from 'prop-types';
+import {
+  withStyles,
+  AjaxDialog,
+  DialogContent,
+  DialogContentText,
+  ProgressButton,
+  TextField,
+  Typography,
+} from '../../components/elements';
+
+class UndoMergeGeneDialog extends Component {
+
+  submitData = (data) => {
+    return mockFetchOrNot(
+      (mockFetch) => {
+        return mockFetch.delete('*', {
+          'live': 'WB1',
+          'dead': 'WB2',
+        });
+      },
+      () => {
+        return this.props.authorizedFetch(`/api/gene/${this.props.wbIdMergeInto}/split/${this.props.wbId}`, {
+          method: 'DELETE',
+        });
+      },
+    );
+  }
+
+  render() {
+    const {wbId, wbIdMergeInto, geneName, geneNameMergeInto, authorizedFetch, ...otherProps} = this.props;
+    return (
+      <AjaxDialog
+        title="Undo gene merge"
+        submitter={this.submitData}
+        renderSubmitButton={(props) => (
+          <ProgressButton {...props}>Split {geneNameMergeInto}</ProgressButton>
+        )}
+        {...otherProps}>
+        {
+          ({withFieldData, errorMessage}) => {
+            const ReasonField = withFieldData(TextField, 'provenance/why');
+            return (
+              <DialogContent>
+                <DialogContentText>
+                  Gene <strong>{geneName}</strong> will be split from <strong>{geneNameMergeInto}</strong>.
+                  Are you sure?
+                </DialogContentText>
+                <DialogContentText>
+                  <Typography color="error">{errorMessage}</Typography>
+                </DialogContentText>
+                <ReasonField
+                  label="Reason"
+                  helperText="Enter the reason for killing the gene"
+                  required
+                  fullWidth
+                />
+              </DialogContent>
+            )
+          }
+        }
+      </AjaxDialog>
+    );
+  }
+}
+
+UndoMergeGeneDialog.propTypes = {
+  wbId: PropTypes.string.isRequired,
+  wbIdMergeInto: PropTypes.string.isRequired,
+  geneName: PropTypes.string.isRequired,
+  geneNameMergeInto: PropTypes.string.isRequired,
+  authorizedFetch: PropTypes.func.isRequired,
+};
+
+const styles = (theme) => ({
+  UndoMergeButton: {
+    color: theme.palette.error.main,
+    textTransform: 'inherit',
+  },
+});
+
+export default withStyles(styles)(UndoMergeGeneDialog);

--- a/client/src/containers/Gene/UndoSplitGeneDialog.js
+++ b/client/src/containers/Gene/UndoSplitGeneDialog.js
@@ -11,7 +11,7 @@ import {
   Typography,
 } from '../../components/elements';
 
-class UndoMergeGeneDialog extends Component {
+class UndoSplitGeneDialog extends Component {
 
   submitData = (data) => {
     return mockFetchOrNot(
@@ -22,7 +22,7 @@ class UndoMergeGeneDialog extends Component {
         });
       },
       () => {
-        return this.props.authorizedFetch(`/api/gene/${this.props.wbId}/merge/${this.props.wbFromId}`, {
+        return this.props.authorizedFetch(`/api/gene/${this.props.wbId}/split/${this.props.wbIntoId}`, {
           method: 'DELETE',
         });
       },
@@ -30,13 +30,13 @@ class UndoMergeGeneDialog extends Component {
   }
 
   render() {
-    const {wbId, wbFromId, geneName, geneFromName, authorizedFetch, ...otherProps} = this.props;
+    const {wbId, wbIntoId, geneName, geneIntoName, authorizedFetch, ...otherProps} = this.props;
     return (
       <AjaxDialog
-        title="Undo gene merge"
+        title="Undo gene split"
         submitter={this.submitData}
         renderSubmitButton={(props) => (
-          <ProgressButton {...props}>Split {geneFromName}</ProgressButton>
+          <ProgressButton {...props}>Merge into {geneIntoName}</ProgressButton>
         )}
         {...otherProps}>
         {
@@ -45,7 +45,7 @@ class UndoMergeGeneDialog extends Component {
             return (
               <DialogContent>
                 <DialogContentText>
-                  Gene <strong>{geneName}</strong> will be split from <strong>{geneFromName}</strong>.
+                  Gene <strong>{geneName}</strong> will be merged into <strong>{geneIntoName}</strong>.
                   Are you sure?
                 </DialogContentText>
                 <DialogContentText>
@@ -53,7 +53,7 @@ class UndoMergeGeneDialog extends Component {
                 </DialogContentText>
                 <ReasonField
                   label="Reason"
-                  helperText="Enter the reason for undoing the merge"
+                  helperText="Enter the reason for undoing the split"
                   required
                   fullWidth
                 />
@@ -66,19 +66,19 @@ class UndoMergeGeneDialog extends Component {
   }
 }
 
-UndoMergeGeneDialog.propTypes = {
+UndoSplitGeneDialog.propTypes = {
   wbId: PropTypes.string.isRequired,
-  wbFromId: PropTypes.string.isRequired,
+  wbIntoId: PropTypes.string.isRequired,
   geneName: PropTypes.string.isRequired,
-  geneFromName: PropTypes.string.isRequired,
+  geneIntoName: PropTypes.string.isRequired,
   authorizedFetch: PropTypes.func.isRequired,
 };
 
 const styles = (theme) => ({
-  UndoMergeButton: {
+  UndoSplitButton: {
     color: theme.palette.error.main,
     textTransform: 'inherit',
   },
 });
 
-export default withStyles(styles)(UndoMergeGeneDialog);
+export default withStyles(styles)(UndoSplitGeneDialog);

--- a/client/src/containers/Gene/UndoSplitGeneDialog.js
+++ b/client/src/containers/Gene/UndoSplitGeneDialog.js
@@ -36,7 +36,7 @@ class UndoSplitGeneDialog extends Component {
         title="Undo gene split"
         submitter={this.submitData}
         renderSubmitButton={(props) => (
-          <ProgressButton {...props}>Merge into {geneIntoName}</ProgressButton>
+          <ProgressButton {...props}>Merge into {geneName}</ProgressButton>
         )}
         {...otherProps}>
         {
@@ -45,7 +45,7 @@ class UndoSplitGeneDialog extends Component {
             return (
               <DialogContent>
                 <DialogContentText>
-                  Gene <strong>{geneName}</strong> will be merged into <strong>{geneIntoName}</strong>.
+                  Gene <strong>{geneIntoName}</strong> will be merged into <strong>{geneName}</strong>.
                   Are you sure?
                 </DialogContentText>
                 <DialogContentText>

--- a/client/src/containers/Gene/index.js
+++ b/client/src/containers/Gene/index.js
@@ -9,7 +9,7 @@ import GeneSearchBox from './GeneSearchBox';
 import RecentActivities from './RecentActivities';
 
 const Gene = (props) => {
-  const {classes} = props;
+  const {classes, authorizedFetch} = props;
   return (
     <Page>
       <div className={classes.root}>
@@ -30,7 +30,7 @@ const Gene = (props) => {
         {/* tables and charts */}
         <Typography variant="title" gutterBottom>Recent activities</Typography>
         <div className={classes.recentActivitiesTable}>
-          <RecentActivities />
+          <RecentActivities authorizedFetch={authorizedFetch} />
         </div>
       </div>
       </div>
@@ -40,6 +40,7 @@ const Gene = (props) => {
 
 Gene.propTypes = {
   classes: PropTypes.object.isRequired,
+  authorizedFetch: PropTypes.func,
 };
 
 const styles = (theme) => ({


### PR DESCRIPTION
**WARNING: relies on #38 . Please ensure #38 is merged before reviewing this one.**

- dialogs for resurrect, undo merge, and undo split
- factor out `<GeneActivitiesTable>` component for use on both the gene profile page and gene directory page
- Update GeneActivitiesTable based on speculated schema of activities data (in particular the "directionality" of a merge and split")