### PR TITLE
Feature/gene history

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -31,13 +31,12 @@
   metosin/spec-tools {:mvn/version "0.7.1"}
   metosin/muuntaja {:mvn/version "0.6.0-alpha1"}
   mount {:mvn/version "0.1.12"}
-  phrase {:mvn/version "0.3-alpha3"} ;; TODO: use for better API error messages.
   ring/ring-codec {:mvn/version "1.1.0"}
   ring/ring-core {:mvn/version "1.6.3"}
   ring/ring-defaults {:mvn/version "0.3.1"}
   ring/ring-jetty-adapter {:mvn/version "1.6.3"}
   semantic-csv {:mvn/version "0.2.1-alpha1"}
- }
+  com.taoensso/encore {:mvn/version "2.97.0"}}
 
  ;; aliases
  ;;   resolve-deps aliases (-R) affect dependency resolution, options:

--- a/src/wormbase/names/gene.clj
+++ b/src/wormbase/names/gene.clj
@@ -92,12 +92,13 @@
 (defn about-gene [request identifier]
   (when (s/valid? ::wsg/identifier identifier)
     (let [db (:db request)
-          [lur ent] (identify request identifier)
+          [lur _] (identify request identifier)
           info-expr '[*
                       {:gene/biotype [[:db/ident]]
                        :gene/species [[:species/id][:species/latin-name]]
                        :gene/status [[:db/ident]]}]
-          data (d/pull db info-expr lur)]
+          data (-> (d/pull db info-expr lur)
+                   (assoc :history (wnp/query-provenance db lur)))]
       (http-response/ok (transform-result data)))))
 
 (defn new-unnamed-gene [request payload]

--- a/src/wormbase/names/gene.clj
+++ b/src/wormbase/names/gene.clj
@@ -26,7 +26,7 @@
       (throw (ex-info "No names to validate (empty data)"
                       {:type :user/validation-error})))
     (if-not species-ent
-      (throw (ex-info "Invalid species specied"
+      (throw (ex-info "Invalid species specified"
                       {:invalid-species species-lur
                        :type :user/validation-error})))
     (let [patterns ((juxt :species/cgc-name-pattern

--- a/src/wormbase/names/gene.clj
+++ b/src/wormbase/names/gene.clj
@@ -102,7 +102,7 @@
       (http-response/ok (transform-result data)))))
 
 (defn new-unnamed-gene [request payload]
-  (let [prov (wnp/assoc-provenence request payload :event/new-gene)
+  (let [prov (wnp/assoc-provenance request payload :event/new-gene)
         data (wnu/select-keys-with-ns payload "gene")
         spec ::wsg/new-unnamed
         cdata (if (s/valid? spec data)
@@ -128,7 +128,7 @@
                                          :type ::validation-error
                                          :data data})))
                       conformed))
-        prov (wnp/assoc-provenence request payload :event/new-gene)
+        prov (wnp/assoc-provenance request payload :event/new-gene)
         tx-data [[:wormbase.tx-fns/new-gene cdata mint-new-id?] prov]
         tx-result @(d/transact-async (:conn request) tx-data)
         db (:db-after tx-result)
@@ -147,7 +147,7 @@
             data (wnu/select-keys-with-ns payload "gene")]
         (if (s/valid? ::wsg/update data)
           (let [cdata (stc/conform spec (validate-names request data))
-                prov (wnp/assoc-provenence request payload :event/update-gene)
+                prov (wnp/assoc-provenance request payload :event/update-gene)
                 txes [[:wormbase.tx-fns/update-gene lur cdata]
                       prov]
                 tx-result @(d/transact-async conn txes)]
@@ -211,7 +211,7 @@
                                            from-id
                                            into-biotype)
         prov (-> request
-                 (wnp/assoc-provenence data :event/merge-genes)
+                 (wnp/assoc-provenance data :event/merge-genes)
                  (assoc :provenance/merged-from from-lur)
                  (assoc :provenance/merged-into into-lur))
         tx-result @(d/transact-async
@@ -258,7 +258,7 @@
              p-biotype :gene/biotype} product
             p-seq-name (get-in cdata [:product :gene/sequence-name])
             prov-from (-> request
-                          (wnp/assoc-provenence cdata :event/split-gene)
+                          (wnp/assoc-provenance cdata :event/split-gene)
                           (assoc :provenance/split-into p-seq-name)
                           (assoc :provenance/split-from [:gene/id id]))
             species (-> existing-gene :gene/species :species/id)
@@ -339,7 +339,7 @@
                        :lookup-ref lur})))
     (when ent
       (let [payload (some->> request :body-params)
-            prov (wnp/assoc-provenence request payload :event/kill-gene)
+            prov (wnp/assoc-provenance request payload :event/kill-gene)
             tx-result @(d/transact-async
                         (:conn request)
                         [[:wormbase.tx-fns/kill-gene lur] prov])]

--- a/src/wormbase/names/gene.clj
+++ b/src/wormbase/names/gene.clj
@@ -38,7 +38,7 @@
           (when-not (re-matches regexp gname)
             (throw (ex-info "Invalid name"
                             {:type :user/validation-error
-                             :invalid {:name  gname :ident name-ident}})))))))
+                             :invalid {:name gname :ident name-ident}})))))))
   data)
 
 (def name-matching-rules

--- a/src/wormbase/names/gene.clj
+++ b/src/wormbase/names/gene.clj
@@ -6,7 +6,6 @@
    [datomic.api :as d]
    [java-time :as jt]
    [wormbase.db :as wdb]
-   [wormbase.names.agent :as wn-agent]
    [wormbase.names.auth :as wna]
    [wormbase.names.entity :as wne]
    [wormbase.names.provenance :as wnp]

--- a/src/wormbase/names/person.clj
+++ b/src/wormbase/names/person.clj
@@ -26,7 +26,7 @@
                           {:type :user/validation-error
                            :problems problems})))
         (let [tempid "datomic.tx"
-              prov (wnp/assoc-provenence request person :event/new-person)
+              prov (wnp/assoc-provenance request person :event/new-person)
               tx-data [(assoc person :person/active? true) prov]
               tx-res @(d/transact conn tx-data)
               pid (wdb/extract-id tx-res :person/id)]

--- a/src/wormbase/names/provenance.clj
+++ b/src/wormbase/names/provenance.clj
@@ -98,5 +98,6 @@
          (map pull)
          (map undatomicize)
          (remove #(= (:provenance/what %) :event/import-gene))
+         (map #(update % :provenance/how (fnil identity :agent/importer)))
          (sort-mrf)
          seq)))

--- a/src/wormbase/names/provenance.clj
+++ b/src/wormbase/names/provenance.clj
@@ -19,7 +19,7 @@
         (s/conform ::wsp/identifier who))
       (first (vec who)))))
 
-(defn assoc-provenence
+(defn assoc-provenance
   "Associate provenance data with the request.
 
   Fill in defaults where not specified by the request.

--- a/src/wormbase/specs/agent.clj
+++ b/src/wormbase/specs/agent.clj
@@ -6,8 +6,7 @@
 
 (s/def :agent/web keyword?)
 
-(def all-agents #{:agent/console :agent/web})
+(def all-agents #{:agent/console :agent/web :agent/importer})
 
-(s/def ::agent all-agents)
+(s/def ::id all-agents)
 
-(s/def :agent/id ::agent)

--- a/src/wormbase/specs/gene.clj
+++ b/src/wormbase/specs/gene.clj
@@ -96,9 +96,23 @@
 
 (s/def ::kill-response (stc/spec (s/keys :req-un [::killed])))
 
+(s/def ::provenance (s/keys :req [:provenance/when
+                                  :provenance/who
+                                  :provenance/how]
+                            :opt [:provenance/why
+                                  :provenance/split-from
+                                  :provenance/split-into
+                                  :provenance/merged-from
+                                  :provenance/merged-into]))
+
+(s/def ::history (s/coll-of ::provenance :type vector? :min-count 1))
+
 (s/def ::info (stc/spec (s/keys :req [:gene/id
                                       :gene/species
-                                      :gene/status]
+                                      :gene/status
+                                      (or (or :gene/cgc-name :gene/sequence-name)
+                                          (and :gene/cgc-name :gene/sequence-name))]
+                                :req-un [::history]
                                 :opt [:gene/biotype
                                       :gene/sequence-name
                                       :gene/cgc-name])))

--- a/src/wormbase/specs/provenance.clj
+++ b/src/wormbase/specs/provenance.clj
@@ -7,8 +7,6 @@
    [spec-tools.core :as stc]
    [spec-tools.spec :as sts]))
 
-(s/def :agent/id sts/string?)
-
 ;; TODO: clients should provide zoned-date-time (times in UTC)
 ;;       - db wants instants (java.utl.Date values)
 
@@ -16,7 +14,7 @@
 
 (s/def :provenance/who (stc/spec (s/keys :req [(or :person/id :person/email)])))
 
-(s/def :provenance/how (stc/spec (s/keys :req-un [::wsa/agent])))
+(s/def :provenance/how (stc/spec ::wsa/id))
 
 (s/def :provenance/why (stc/spec (s/and sts/string? (complement str/blank?))))
 

--- a/test/integration/test_about_gene.clj
+++ b/test/integration/test_about_gene.clj
@@ -23,9 +23,6 @@
 
 (def about-gene (partial api-tc/info "gene"))
 
-(defn- check-gene-data []
-  (assert false "TBD"))
-
 (t/deftest test-about-live
   (t/testing "Info about a live gene can be retrieved by WBGene ID."
     (let [[id data-sample] (gen-sample)]

--- a/test/integration/test_about_gene.clj
+++ b/test/integration/test_about_gene.clj
@@ -23,7 +23,7 @@
 
 (def about-gene (partial api-tc/info "gene"))
 
-(t/deftest test-about-live
+(t/deftest test-about
   (t/testing "Info about a live gene can be retrieved by WBGene ID."
     (let [[id data-sample] (gen-sample)]
       (tu/with-gene-fixtures

--- a/test/integration/test_find_gene_by_any_name.clj
+++ b/test/integration/test_find_gene_by_any_name.clj
@@ -13,11 +13,10 @@
 (defn find-gene
   [pattern & {:keys [current-user]
               :or {current-user "tester@wormbase.org"}}]
-  (binding [fake-auth/*gapi-verify-token-response* {"email" current-user}]
-    (let [current-user-token (get fake-auth/tokens current-user)
-          params {:pattern pattern}
+  (binding [fake-auth/*gapi-verify-token-response* (fake-auth/payload {"email" current-user})]
+    (let [params {:pattern pattern}
           headers {"content-type" "application/json"
-                   "authorization" (str "Token " current-user-token)}
+                   "authorization" "Token IsTotallyMadeUp"}
           [status body] (tu/get*
                          service/app
                          (str "/api/gene/")


### PR DESCRIPTION
Adds history to the info endpoint for Gene.
In the response returned for GET requests (i.e `GET /api/gene/<identifier>`),
there will be a "history" key containing a sequence of mappings.
Each mapping can contain key value paris from the provenance namespace, as specified by
`wormbase.specs.gene/provenenance`.
This should always be at a sequence of min-length 1.
 