### PR TITLE
Feature/provenance for undo operations

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -51,6 +51,7 @@
             {org.clojure/test.check {:mvn/version  "0.9.0"}
              org.clojure/tools.trace {:mvn/version  "0.7.9"}
              org.clojure/tools.nrepl {:mvn/version "0.2.13"}
+             com.cognitect/transcriptor {:mvn/version "0.1.5"}
              acyclic/squiggly-clojure {:mvn/version "0.1.9-SNAPSHOT"
                                        :exclusions [org.clojure/tools.reader]}
              com.velisco/strgen {:mvn/version "0.1.5"

--- a/resources/schema/seed-data.edn
+++ b/resources/schema/seed-data.edn
@@ -73,7 +73,9 @@
  #:db{:ident :event/new-unnamed-gene}
  #:db{:ident :event/update-gene}
  #:db{:ident :event/merge-genes}
+ #:db{:ident :event/undo-merge-genes}
  #:db{:ident :event/split-gene}
+ #:db{:ident :event/undo-split-gene}
  #:db{:ident :event/kill-gene}
  #:db{:ident :event/resurrect-gene}
  #:db{:ident :event/suppress-gene}

--- a/resources/schema/updates/2018-10-29_event-types.repl
+++ b/resources/schema/updates/2018-10-29_event-types.repl
@@ -1,0 +1,5 @@
+(require '[cognitect.transcriptor :as xr :refer (check!)])
+(require '[datomic.api :as d])
+(require '[wormbase.db :as wdb])
+@(d/transact wdb/conn [(wdb/seed-data-schema :event/undo-split-gene)])
+@(d/transact wdb/conn [(wdb/seed-data-schema :event/undo-merge-genes)])

--- a/src/wormbase/db.clj
+++ b/src/wormbase/db.clj
@@ -122,6 +122,10 @@
          (filter ident-match?)
          (first))))
 
+;; convenience aliases to read schema items from resources by keyword.
+
+(def seed-data-schema (partial edn-definition "seed-data"))
+
 (def attr-schema (partial edn-definition "definitions"))
 
 (def txfn-schema (partial edn-definition "tx-fns"))

--- a/test/integration/test_new_gene.clj
+++ b/test/integration/test_new_gene.clj
@@ -3,7 +3,6 @@
    [clojure.test :as t]
    [datomic.api :as d]
    [wormbase.api-test-client :as api-tc]
-   [wormbase.fake-auth :as fake-auth]
    [wormbase.db-testing :as db-testing]
    [wormbase.gen-specs.species :as gss]
    [wormbase.names.service :as service]


### PR DESCRIPTION
@sibyl229 
This adds provenance for `undo-split-gene`, `undo-merge-gene` and `resurrect-gene` events.
All data transacted for genes should now have full accompanying provenance attached.

To test this, you'll first need to apply the following schema at a repl connected to the running server:
```clojure
(require '[cognitect.transcriptor :as xr]) 
(doseq [upd (xr/repl-files "resources/schema/updates")]
  (xr/run upd))
```
(Tested this works w/copy-and-paste)
Fixes #44 
Implements #7 