### PR TITLE
Fixed response format for resurrect gene API.

### DIFF
--- a/src/wormbase/names/errhandlers.clj
+++ b/src/wormbase/names/errhandlers.clj
@@ -54,8 +54,8 @@
 
 (defn assoc-error-message [data exc]
   (if-let [msg (.getMessage exc)]
-    (assoc data :message msg)
-    data))
+    (assoc data :message msg :info data)
+    {:message "No reason given." :info data}))
 
 (defn handle-validation-error [^Exception exc data request]
   (let [problems (get-in data [:data :problems])

--- a/src/wormbase/names/provenance.clj
+++ b/src/wormbase/names/provenance.clj
@@ -72,16 +72,6 @@
                :provenance/merged-into [:gene/id]}]
           tx-id))
 
-(defn- undatomicize
-  "Remove datomic internal attribute/value pairs from a seq of maps."
-  [data]
-  (w/postwalk (fn presenter [m]
-                (cond
-                  (and (map? m) (:db/ident m)) (:db/ident m)
-                  (map? m) (dissoc m :db/id :db/txInstant)
-                  :default m))
-              data))
-
 (defn query-provenance
   "Query for the entire history of an entity `entity-id`.
   `entity-id` can be a datomic id number or a lookup-ref."
@@ -95,7 +85,7 @@
               (d/history db)
               entity-id)
          (map pull)
-         (map undatomicize)
+         (map wnu/undatomicize)
          (remove #(= (:provenance/what %) :event/import-gene))
          (map #(update % :provenance/how (fnil identity :agent/importer)))
          (sort-mrf)

--- a/src/wormbase/specs/common.clj
+++ b/src/wormbase/specs/common.clj
@@ -5,8 +5,6 @@
 
 (s/def ::info sts/map?)
 
-(s/def ::spec (stc/spec (s/keys :req-un [::info])))
+(s/def ::message sts/string?)
 
-(s/def ::error-response (stc/spec (s/keys :req-un [::spec])))
-
-(s/def ::conflict-response (stc/spec (s/keys :req-un [::info])))
+(s/def ::error-response (stc/spec (s/keys :req-un [::info ::message])))

--- a/src/wormbase/specs/provenance.clj
+++ b/src/wormbase/specs/provenance.clj
@@ -18,4 +18,12 @@
 
 (s/def :provenance/why (stc/spec (s/and sts/string? (complement str/blank?))))
 
-(s/def :provenance/merged-from (stc/spec (s/keys :req [:gene/id])))
+(s/def ::gene-ref (stc/spec (s/keys :req [:gene/id])))
+
+(s/def :provenance/merged-from ::gene-ref)
+
+(s/def :provenance/merged-into ::gene-ref)
+
+(s/def :provenance/split-from ::gene-ref)
+
+(s/def :provenance/split-into ::gene-ref)

--- a/test/integration/test_resurrect_gene.clj
+++ b/test/integration/test_resurrect_gene.clj
@@ -1,0 +1,55 @@
+(ns integration.test-resurrect-gene
+  (:require
+   [clojure.spec.gen.alpha :as gen]
+   [clojure.test :as t]
+   [datomic.api :as d]
+   [wormbase.api-test-client :as api-tc]
+   [wormbase.db-testing :as db-testing]
+   [wormbase.fake-auth :as fake-auth]
+   [wormbase.gen-specs.gene :as gsg]
+   [wormbase.names.service :as service]
+   [wormbase.specs.agent :as wsa]
+   [wormbase.test-utils :as tu]
+   [ring.util.http-response :as http-response]))
+
+(t/use-fixtures :each db-testing/db-lifecycle)
+
+(defn- gen-sample-for-resurrect [& {:keys [live?]
+                                    :or {live? false}}]
+  (let [[sample] (tu/gene-samples 1)
+        gene-id (first (gen/sample gsg/id 1))
+        species (-> sample :gene/species :species/id)
+        prod-seq-name (tu/seq-name-for-species species)
+        data-sample (assoc sample
+                           :gene/id gene-id
+                           :gene/sequence-name (tu/seq-name-for-species species)
+                           :gene/cgc-name (tu/cgc-name-for-species species)
+                           :gene/status (if live?
+                                          :gene.status/live
+                                          :gene.status/dead))]
+    [gene-id data-sample]))
+
+(defn resurrect-gene
+  [gene-id & {:keys [current-user]
+              :or {current-user "tester@wormbase.org"}}]
+  (api-tc/send-request "gene" :post {}
+                       :sub-path (str gene-id "/resurrect")
+                       :current-user current-user))
+
+(t/deftest cases
+  (t/testing "Resurrecting a dead gene succesfully"
+    (let [[gene-id sample] (gen-sample-for-resurrect)]
+      (tu/with-gene-fixtures
+        sample
+        (fn [conn]
+          (let [[status body] (resurrect-gene gene-id)]
+            (tu/status-is? status (:status (http-response/ok)) body))))))
+  (t/testing "Cannot resurrect live gene"
+    (let [[gene-id sample] (gen-sample-for-resurrect :live? true)]
+      (tu/with-gene-fixtures
+        sample
+        (fn [conn]
+          (let [[status body] (resurrect-gene gene-id)]
+            (tu/status-is? status (:status (http-response/precondition-failed))
+                           body)))))))
+


### PR DESCRIPTION
- Corrected misspelling of "resurrect" in various places.
- Unified format for error responses.
- Added simple tests for resurrect gene API.
- Moved the `undatomicize` function to wormbase.names.util namespace.
- Corrected provenance specs.

Fixes #58.