### PR TITLE
Bugfix/spec validation for gene update

### DIFF
--- a/src/wormbase/names/agent.clj
+++ b/src/wormbase/names/agent.clj
@@ -10,7 +10,7 @@
 
 (defn identify [^GoogleIdToken$Payload token]
   (let [app-conf (wnu/read-app-config)
-        client-types wsa/all-agents
+        client-types (:form wsa/all-agents)
         client-id-map (zipmap
                        (map #(-> gapps-conf % :client-id)
                             (map (comp keyword name) client-types))

--- a/src/wormbase/names/coercion.clj
+++ b/src/wormbase/names/coercion.clj
@@ -33,8 +33,8 @@
                     (assoc-in
                      [:body :formats]
                      {"application/json" json-transformer
-                     "application/msgpack" json-transformer
-                     "application/x-yaml" json-transformer})
+                      "application/msgpack" json-transformer
+                      "application/x-yaml" json-transformer})
                     (assoc-in [:body :string :default] string-transformer))]
     (spec-coercion/create-coercion options)))
 

--- a/src/wormbase/names/coercion.clj
+++ b/src/wormbase/names/coercion.clj
@@ -1,7 +1,8 @@
 (ns wormbase.names.coercion
-  [compojure.api.coercion.spec :as spec-coercion]
-  [spec-tools.core :as stc]
-  [spec-tools.transform :as stt])
+  (:require
+   [compojure.api.coercion.spec :as spec-coercion]
+   [spec-tools.core :as stc]
+   [spec-tools.transform :as stt]))
 
 ;;; Modified copies of the original transformers:
 ;;; https://github.com/metosin/compojure-api/blob/master/src/compojure/api/coercion/spec.clj#L16-L35
@@ -34,7 +35,7 @@
                     (assoc-in [:body :string :default] string-transformer))]
     (spec-coercion/create-coercion options)))
 
-(def ^:{:doc "Custom coercion that doesn't strip keys from specs during response processing."}
+(def ^{:doc "Custom coercion that doesn't strip keys from specs during response processing."}
   spec (non-stripping-spec-keys-coercion))
 
 

--- a/src/wormbase/names/coercion.clj
+++ b/src/wormbase/names/coercion.clj
@@ -1,5 +1,6 @@
 (ns wormbase.names.coercion
   (:require
+   [compojure.api.coercion.core :as cc]
    [compojure.api.coercion.spec :as spec-coercion]
    [spec-tools.core :as stc]
    [spec-tools.transform :as stt]))
@@ -31,11 +32,15 @@
         options (-> spec-coercion/default-options
                     (assoc-in
                      [:body :formats]
-                     (zipmap mimetypes (repeat json-transformer)))
+                     {"application/json" json-transformer
+                     "application/msgpack" json-transformer
+                     "application/x-yaml" json-transformer})
                     (assoc-in [:body :string :default] string-transformer))]
     (spec-coercion/create-coercion options)))
 
 (def ^{:doc "Custom coercion that doesn't strip keys from specs during response processing."}
-  spec (non-stripping-spec-keys-coercion))
+  pure-spec (non-stripping-spec-keys-coercion))
+
+(defmethod cc/named-coercion :pure-spec [_] pure-spec)
 
 

--- a/src/wormbase/names/coercion.clj
+++ b/src/wormbase/names/coercion.clj
@@ -1,0 +1,40 @@
+(ns wormbase.names.coercion
+  [compojure.api.coercion.spec :as spec-coercion]
+  [spec-tools.core :as stc]
+  [spec-tools.transform :as stt])
+
+;;; Modified copies of the original transformers:
+;;; https://github.com/metosin/compojure-api/blob/master/src/compojure/api/coercion/spec.clj#L16-L35
+;;
+;; The only change to remove the `spec-tools.transform/strip-extra-keys-type-decoders` from
+;; the decoders applied to response formats.
+
+(def string-transformer
+  (stc/type-transformer
+    {:name :string
+     :decoders stt/string-type-decoders
+     :encoders stt/string-type-encoders
+     :default-encoder stt/any->any}))
+
+(def json-transformer
+  (stc/type-transformer
+    {:name :json
+     :decoders stt/json-type-decoders
+     :encoders stt/json-type-encoders
+     :default-encoder stt/any->any}))
+
+(defn non-stripping-spec-keys-coercion
+  "Creates a new spec coercion without the extra-keys stripping in response formats."
+  []
+  (let [mimetypes (-> spec-coercion/default-options :body keys)
+        options (-> spec-coercion/default-options
+                    (assoc-in
+                     [:body :formats]
+                     (zipmap mimetypes (repeat json-transformer)))
+                    (assoc-in [:body :string :default] string-transformer))]
+    (spec-coercion/create-coercion options)))
+
+(def ^:{:doc "Custom coercion that doesn't strip keys from specs during response processing."}
+  spec (non-stripping-spec-keys-coercion))
+
+

--- a/src/wormbase/names/gene.clj
+++ b/src/wormbase/names/gene.clj
@@ -111,7 +111,7 @@
         spec ::wsg/new-unnamed
         cdata (if (s/valid? spec data)
                 (s/conform spec data)
-                (let [problems (s/explain-data spec data)]
+                (let [problems (expound-str spec data)]
                   (throw (ex-info "Invalid data"
                                   {:problems problems
                                    :type ::validation-error
@@ -121,10 +121,10 @@
 
 (defn conform-gene-data [request spec data]
   (let [conformed (stc/conform spec (validate-names request data))]
-    (if (= ::s/invalid conformed)
-      (let [problems (s/explain-data spec data)]
+    (if (s/invalid? conformed)
+      (let [problems (expound-str spec data)]
         (throw (ex-info "Not valid according to spec."
-                        {:problems (str problems)
+                        {:problems problems
                          :type ::validation-error
                          :data data})))
       conformed)))
@@ -180,7 +180,7 @@
               (http-response/not-found
                (format "Gene '%s' does not exist" (last lur)))))
           (throw (ex-info "Not valid according to spec."
-                          {:problems (str (s/explain-data spec data))
+                          {:problems (expound-str spec data)
                            :type ::validation-error
                            :data data})))))))
 
@@ -204,9 +204,7 @@
     (when-not (and (s/valid? :gene/biotype into-biotype)
                    (wdb/ident-exists? db into-biotype))
       (throw (ex-info "Invalid biotype"
-                      {:problems (str (s/explain-data
-                                       :gene/biotype
-                                       into-biotype))
+                      {:problems (expound-str :gene/biotype into-biotype)
                        :type ::validation-error})))
     (when (reduce not=
                   (map :gene/species [from-gene into-gene]))

--- a/src/wormbase/names/person.clj
+++ b/src/wormbase/names/person.clj
@@ -4,6 +4,7 @@
    [compojure.api.routes :as route]
    [compojure.api.sweet :as sweet]
    [datomic.api :as d]
+   [expound.alpha :refer [expound-str]]
    [wormbase.db :as wdb]
    [wormbase.specs.person :as wsp]
    [wormbase.names.auth :as wna]
@@ -21,7 +22,7 @@
         person (some-> request :body-params)]
     (let [transformed (stc/conform spec person stc/json-transformer)]
       (if (= transformed ::s/invalid)
-        (let [problems (str (s/explain-data spec person))]
+        (let [problems (expound-str  spec person)]
           (throw (ex-info "Invalid person data"
                           {:type :user/validation-error
                            :problems problems})))
@@ -71,7 +72,7 @@
             (http-response/ok (info (:db-after tx-res) lur)))
           (http-response/bad-request
            {:type :user/validation-error
-            :problems (s/explain-data spec data*)}))))))
+            :problems (expound-str spec data*)}))))))
 
 (defn deactivate-person [identifier request]
   (admin-required request)
@@ -87,7 +88,7 @@
       (handler identifier request)
       (throw (ex-info "Invalid person identifier"
                       {:type :user/validation-error
-                       :problems (s/explain-data ::wsp/identifier identifier)})))))
+                       :problems (expound-str ::wsp/identifier identifier)})))))
 
 (def routes
   (sweet/routes

--- a/src/wormbase/names/service.clj
+++ b/src/wormbase/names/service.clj
@@ -11,6 +11,7 @@
    [muuntaja.middleware :as mmw]
    [wormbase.db :as wdb]
    [wormbase.names.auth :as wna]
+   [wormbase.names.coercion :as wnc]
    [wormbase.names.errhandlers :as wn-eh]
    [wormbase.names.gene :as wn-gene]
    [wormbase.names.person :as wn-person]
@@ -78,7 +79,7 @@
 
 (def ^{:doc "The main application."} app
   (sweet/api
-   {:coercion :spec
+   {:coercion wnc/spec
     :middleware [ring-gzip/wrap-gzip
                  wrap-static-resources
                  wrap-not-found

--- a/src/wormbase/names/service.clj
+++ b/src/wormbase/names/service.clj
@@ -11,7 +11,7 @@
    [muuntaja.middleware :as mmw]
    [wormbase.db :as wdb]
    [wormbase.names.auth :as wna]
-   [wormbase.names.coercion :as wnc]
+   [wormbase.names.coercion] ;; coercion scheme
    [wormbase.names.errhandlers :as wn-eh]
    [wormbase.names.gene :as wn-gene]
    [wormbase.names.person :as wn-person]
@@ -82,7 +82,8 @@
 
 (def ^{:doc "The main application."} app
   (sweet/api
-   {:coercion wnc/spec
+   {:formats mformats
+    :coercion :pure-spec
     :middleware [ring-gzip/wrap-gzip
                  wrap-static-resources
                  wrap-not-found

--- a/src/wormbase/names/service.clj
+++ b/src/wormbase/names/service.clj
@@ -33,7 +33,7 @@
       response
       (cond
         (str/starts-with? (:uri request) "/api")
-        (http-response/not-found {:reason "Resource not found"})
+        (http-response/not-found {:message "Resource not found"})
 
         :else
         (-> (http-response/resource-response "client_build/index.html")

--- a/src/wormbase/names/service.clj
+++ b/src/wormbase/names/service.clj
@@ -43,6 +43,9 @@
 (defn decode-content [mime-type content]
   (muuntaja/decode mformats mime-type content))
 
+(defn encode-content [mime-type content]
+  (slurp (muuntaja/encode mformats mime-type content)))
+
 (def ^:private swagger-validator-url
   "The URL used to validate the swagger JSON produced by the application."
   (if-let [validator-url (environ/env :swagger-validator-url)]

--- a/src/wormbase/specs/agent.clj
+++ b/src/wormbase/specs/agent.clj
@@ -1,12 +1,14 @@
 (ns wormbase.specs.agent
   (:require
-   [clojure.spec.alpha :as s]))
+   [clojure.spec.alpha :as s]
+   [spec-tools.core :as stc]
+   [spec-tools.spec :as sts]))
 
-(s/def :agent/console keyword?)
+(s/def :agent/console sts/keyword?)
 
-(s/def :agent/web keyword?)
+(s/def :agent/web sts/keyword?)
 
-(def all-agents #{:agent/console :agent/web :agent/importer})
+(def all-agents (stc/spec #{:agent/console :agent/web :agent/importer}))
 
 (s/def ::id all-agents)
 

--- a/src/wormbase/specs/provenance.clj
+++ b/src/wormbase/specs/provenance.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.spec.alpha :as s]
    [clojure.string :as str]
-   [wormbase.specs.person] ;; for specs
+   [wormbase.specs.person] ;; side effecting: to bring in specs
    [wormbase.specs.agent :as wsa]
    [spec-tools.core :as stc]
    [spec-tools.spec :as sts]))
@@ -11,6 +11,8 @@
 ;;       - db wants instants (java.utl.Date values)
 
 (s/def :provenance/when sts/inst?)
+
+(s/def :provenance/what sts/keyword?)
 
 (s/def :provenance/who (stc/spec (s/keys :req [(or :person/id :person/email)])))
 

--- a/test/integration/test_find_gene_by_any_name.clj
+++ b/test/integration/test_find_gene_by_any_name.clj
@@ -1,12 +1,11 @@
 (ns integration.test-find-gene-by-any-name
   (:require
-   [clojure.spec.gen.alpha :as gen]
+   [clojure.string :as str]
    [clojure.test :as t]
    [wormbase.fake-auth :as fake-auth]
    [wormbase.test-utils :as tu]
    [wormbase.db-testing :as db-testing]
-   [wormbase.names.service :as service]
-   [clojure.string :as str]))
+   [wormbase.names.service :as service]))
 
 (t/use-fixtures :each db-testing/db-lifecycle)
 
@@ -20,11 +19,11 @@
               :or {current-user "tester@wormbase.org"}}]
   (binding [fake-auth/*gapi-verify-token-response* (fake-auth/payload {"email" current-user})]
     (let [params {:pattern pattern}
-          headers {"content-type" "application/json"
+          headers {"accept" "application/json"
                    "authorization" "Token IsTotallyMadeUp"}
           [status body] (tu/get*
                          service/app
-                         (str "/api/gene/")
+                         "/api/gene/"
                          params
                          headers)]
       [status (tu/parse-body body)])))
@@ -36,7 +35,15 @@
                             (int)))))
 
 (t/deftest find-by-any-name
-  (let [data-samples (tu/gene-samples 10)]
+  (t/testing "Get an validation errror (400) result for invalid find terms."
+    (doseq [term [""]]
+      (let [[status body] (find-gene term)]
+        (tu/status-is? 400 status body)
+        (t/is (not (contains? body :matches)))
+        (t/is (re-matches #".*invalid.*" (get body :message ""))
+              (pr-str "BODY:" body))
+        (t/is (:problems body) (pr-str body)))))
+  (let [data-samples (tu/gene-samples 3)]
     (tu/with-gene-fixtures
       data-samples
       (fn test-find-cases [conn]
@@ -51,32 +58,24 @@
                   matches (:matches body)]
               (tu/status-is? 200 status body)
               (t/is (empty? matches)))))
-        (t/testing "Get an validation errror (400) result for invalid find terms."
-          (doseq [term [""]]
-            (let [[status body] (find-gene term)]
-              (tu/status-is? 400 status body)
-              (t/is (not (contains? body :matches)))
-              (t/is (re-matches #".*validation failed.*" (get body :message ""))
-                    (pr-str "BODY:" body))
-              (t/is (:problems body) (pr-str body)))))
         (t/testing "Results found for matching GeneID/CGC/sequence prefixes"
-          (doseq [attr [:gene/id :gene/cgc-name :gene/sequence-name]]
-            (let [sample (rand-nth data-samples)
-                  gid (:gene/id sample)
-                  value (attr sample)
-                  valid-prefix (rand-prefix value)
-                  [status body] (find-gene valid-prefix)
-                  matches (:matches body)]
-              (tu/status-is? 200 status body)
-              (t/is (seq matches)
-                    (str "No matches found for " valid-prefix))
-              (t/is (some (fn [match] (= (:gene/id match) gid)) matches)
-                    (str "Could not find any GeneID matching " gid
-                         " matches:" (pr-str matches)))
-              (t/is (some (fn [match]
-                            (assert (not (nil? match)))
-                            (str/starts-with? (attr match) valid-prefix))
-                          matches)
-                    (str "Could not verify and match startswith prefix "
-                         (pr-str valid-prefix) ""
-                         (pr-str matches))))))))))
+        (doseq [attr [:gene/id :gene/cgc-name :gene/sequence-name]]
+          (let [sample (rand-nth data-samples)
+                gid (:gene/id sample)
+                value (attr sample)
+                valid-prefix (rand-prefix value)
+                [status body] (find-gene valid-prefix)
+                matches (:matches body)]
+            (tu/status-is? 200 status body)
+            (t/is (seq matches)
+                  (str "No matches found for " valid-prefix))
+            (t/is (some (fn [match] (= (:gene/id match) gid)) matches)
+                  (str "Could not find any GeneID matching " gid
+                       " matches:" (pr-str matches)))
+            (t/is (some (fn [match]
+                          (assert (not (nil? match)))
+                          (str/starts-with? (attr match) valid-prefix))
+                        matches)
+                  (str "Could not verify and match startswith prefix "
+                       (pr-str valid-prefix) ""
+                       (pr-str matches))))))))))

--- a/test/integration/test_new_gene.clj
+++ b/test/integration/test_new_gene.clj
@@ -29,32 +29,32 @@
   (t/testing "Incorrectly naming gene reports problems."
     (let [response (new-gene {})
           [status body] response]
-      (tu/status-is? status 400 body)
+      (tu/status-is? 400 status body)
       (t/is (contains? (tu/parse-body body) :message))))
   (t/testing "Species should always be required when creating gene name."
     (let [[status
            body] (new-gene {:gene/cgc-name (tu/cgc-name-for-species
                                             :species/c-elegans)})]
-      (tu/status-is? status 400 (format "Body: " body)))))
+      (tu/status-is? 400 status (format "Body: " body)))))
 
 (t/deftest wrong-data-shape
   (t/testing "Non-conformant data should result in HTTP Bad Request 400"
     (let [[status body] (new-gene {})]
-      (tu/status-is? status 400 (format "Body: " body)))))
+      (tu/status-is? 400 status (format "Body: " body)))))
 
 (t/deftest invalid-species-specified
   (t/testing "What happens when you specify an invalid species"
     (let [[status body] (new-gene
                          {:gene/cgc-name "abc-1"
                           :gene/species {:species/id :species/c-elegant}})]
-      (tu/status-is? status 400 body))))
+      (tu/status-is? 400 status body))))
 
 (t/deftest invalid-names
   (t/testing "Invalid CGC name for species causes validation error."
     (let [[status body] (new-gene
                          {:gene/cgc-name "_INVALID!_"
                           :gene/species {:species/id :species/c-elegans}})]
-      (tu/status-is? status 400 body))))
+      (tu/status-is? 400 status body))))
 
 (t/deftest naming-uncloned
   (t/testing "Naming one uncloned gene succesfully returns ids"
@@ -66,7 +66,7 @@
                                               :species/c-elegans)
                               :gene/species {:species/id :species/c-elegans}})
               expected-id "WBGene00000001"]
-          (tu/status-is? status 201 body)
+          (tu/status-is? 201 status body)
           (let [db (d/db conn)
                 identifier (some-> body :created :gene/id)]
             (t/is (= identifier expected-id))
@@ -80,5 +80,5 @@
                 :provenance/who {:person/email
                                  "tester@wormbase.org"}}
           [status body] (new-gene data)]
-      (tu/status-is? status 201 body)
+      (tu/status-is? 201 status body)
       (t/is (some-> body :created :gene/id) (pr-str body)))))

--- a/test/integration/test_service.clj
+++ b/test/integration/test_service.clj
@@ -25,7 +25,7 @@
       (t/is (contains? response :body))
       (let [decode #(service/decode-content "application/json" %)
             response-text (some-> response :body slurp)]
-        (t/is (not= nil (:reason (decode response-text)))
+        (t/is (not= nil (:message (decode response-text)))
               (str response-text)))))
   (t/testing "When no routes are matched in request processing, client api is served."
     (let [response (service/app

--- a/test/wormbase/test_dbfns.clj
+++ b/test/wormbase/test_dbfns.clj
@@ -201,7 +201,7 @@
                 @(d/transact conn [[:db.fn/cas
                                     [:gene/id latest-id]
                                     :gene/status
-                                    (:gene/status latest-ent)
+                                    (-> latest-ent :gene/status (d/entid db))
                                     (d/entid db :gene.status/dead)]])
                 (let [db (d/db conn)
                       invoke (partial d/invoke db)

--- a/test/wormbase/test_utils.clj
+++ b/test/wormbase/test_utils.clj
@@ -102,8 +102,7 @@
     [status (read-body body) headers]))
 
 (defn get* [app uri & [params headers]]
-  (let [[status body headers]
-        (raw-get* app uri params headers)]
+  (let [[status body headers] (raw-get* app uri params headers)]
     [status (parse-body body) headers]))
 
 (defn form-post* [app uri params]
@@ -240,7 +239,7 @@
       (test-fn conn))))
 
 (defn gene-provenance
-  [data & {:keys [how whence why person status]
+  [data & {:keys [how what whence why person status]
            :or {how :agent/console
                 whence (jt/to-java-date (jt/instant))
                 what :event/test-fixture-assertion
@@ -305,12 +304,16 @@
 (def cgc-name-for-species (partial gen-valid-name-for-species
                                    gss/cgc-name))
 
+(defn uniq-names? [names]
+  (let [nc (count names)]
+    (or (= nc 1)
+        (= nc (-> names set count)))))
+
 (defn dup-names? [data-samples]
   (let [cgc-names (map :gene/cgc-name data-samples)
-        seq-names (map :gene/sequence-name data-samples)
-        uniq? #(= (count (set %)) (count %))]
-    (not (and (uniq? cgc-names)
-              (uniq? seq-names)))))
+        seq-names (map :gene/sequence-name data-samples)]
+    (not (and (uniq-names? cgc-names)
+              (uniq-names? seq-names)))))
 
 (defn gene-samples [n]
   (assert (int? n))
@@ -322,7 +325,7 @@
                          (assoc m
                                 :gene/cgc-name (cgc-name-for-sample m)
                                 :gene/sequence-name (seq-name-for-sample m)))
-                       (gen/sample gsg/update n))
+                       (gen/sample gsg/payload n))
         data-samples (keep-indexed
                       (fn [i gr]
                         (merge (get gene-refs i) gr)) gene-recs)


### PR DESCRIPTION
Hi @sibyl229,

The main change here is to the `spec` used for update gene (now same as the one for new) - which enforces that a gene cannot be edit to something other than a "cloned" or "uncloned" representation.

wormbase.names.coercion: why it's needed:
 - By default, compojure-api's spec implementation strips undefined keys from a spec.
   This would be desirable in most scenarios, but in our case where we have all attributes and two permissable sub-sets, we don't want that.  ATM it's a bit of a chunk of code to change this behaviour, will look into putting a PR for that in upstream.  

The majority of the tests were using the old (incorrect) spec for update for generating input data,
hence all the changes to the tests.

- Steps for testing

   - testing: cloned gene 
     - try blanking/removing sequence name and click edit, should result in validation error

  - testing: uncloned gene
    - try adding a biotype and submitting 

Fixes #75 and provides does the "right thing" with respect to #72 
