### PR TITLE
Feature/78 gene history changes for update

### DIFF
--- a/src/wormbase/specs/gene.clj
+++ b/src/wormbase/specs/gene.clj
@@ -113,23 +113,29 @@
 
 (s/def ::kill-response (stc/spec (s/keys :req-un [::killed])))
 
+
+(s/def ::attr sts/keyword?)
+(s/def ::value any?)
+(s/def ::added sts/boolean?)
+(s/def ::change (s/keys :req-un [::attr ::value ::added]))
+(s/def ::changes (s/coll-of ::change))
 (s/def ::provenance (s/keys :req [:provenance/when
                                   :provenance/who
                                   :provenance/how]
+                            :req-un [::changes]
                             :opt [:provenance/why
                                   :provenance/split-from
                                   :provenance/split-into
                                   :provenance/merged-from
                                   :provenance/merged-into]))
+(s/def ::history (stc/spec (s/coll-of ::provenance :type vector? :min-count 1)))
 
-(s/def ::history (s/coll-of ::provenance :type vector? :min-count 1))
 
 (s/def ::info (stc/spec (s/keys :req [:gene/id
                                       :gene/species
                                       :gene/status
                                       (or (or :gene/cgc-name :gene/sequence-name)
-                                          (and :gene/cgc-name :gene/sequence-name))
-                                      ]
+                                          (and :gene/cgc-name :gene/sequence-name))]
                                 :req-un [::history]
                                 :opt [:gene/biotype
                                       :gene/sequence-name

--- a/test/integration/test_split_gene.clj
+++ b/test/integration/test_split_gene.clj
@@ -150,13 +150,15 @@
       (t/is (re-seq #".*validation failed" (:message body))
             (pr-str body)))))
 
-(defn- gen-sample-for-split []
+(defn- gen-sample-for-split [& {:keys [status]
+                                :or {status :gene.status/live}}]
   (let [[sample] (tu/gene-samples 1)
         gene-id (:gene/id sample)
         species (-> sample :gene/species :species/id)
         prod-seq-name (tu/seq-name-for-species species)]
     [gene-id
      (-> sample
+         (assoc :gene/status status)
          (assoc :gene/id gene-id)
          (dissoc :gene/cgc-name))
      prod-seq-name]))

--- a/test/integration/test_update_gene.clj
+++ b/test/integration/test_update_gene.clj
@@ -20,9 +20,8 @@
 
 (t/deftest must-meet-spec
   (let [identifier (first (gen/sample gsg/id 1))
-        sample (-> (gen/sample gsg/payload 1)
+        sample (-> (tu/gen-sample gsg/cloned 1)
                    (first)
-                   (dissoc :history)
                    (assoc :provenance/who "tester@wormbase.org"))
         sample-data (merge sample {:gene/id identifier})]
     (tu/with-gene-fixtures
@@ -56,7 +55,7 @@
 (t/deftest update-uncloned
   (t/testing "Naming one uncloned gene succesfully."
     (let [gid (first (gen/sample gsg/id 1))
-          sample (-> (gen/sample gsg/uncloned 1)
+          sample (-> (tu/gen-sample gsg/uncloned 1)
                      first
                      (select-keys [:gene/cgc-name :gene/species]))
           sample-data (assoc sample
@@ -82,7 +81,7 @@
 (t/deftest removing-cgc-name-from-cloned-gene
   (t/testing (str "Allow CGC name to be removed from a cloned gene.")
     (let [gid (first (gen/sample gsg/id 1))
-          sample (-> (gen/sample gsg/cloned 1)
+          sample (-> (tu/gen-sample gsg/cloned 1)
                      first
                      (select-keys [:gene/cgc-name :gene/species]))
           sample-data (assoc sample
@@ -107,7 +106,7 @@
 (t/deftest provenance
   (t/testing (str "Provenance is recorded for successful transactions")
    (let [gid (first (gen/sample gsg/id 1))
-         sample (first (gen/sample gsg/cloned 1))
+         sample (first (tu/gen-sample gsg/cloned 1))
          orig-cgc-name (tu/cgc-name-for-sample sample)
          sample-data (merge
                       sample

--- a/test/wormbase/test_dbfns.clj
+++ b/test/wormbase/test_dbfns.clj
@@ -2,15 +2,14 @@
   (:require
    [clojure.spec.alpha :as s]
    [clojure.spec.gen.alpha :as gen]
+   [clojure.string :as str]
    [clojure.test :as t]
    [datomic.api :as d]
-   [miner.strgen :as sg]
    [wormbase.db-testing :as db-testing]
    [wormbase.gen-specs.gene :as gs]
    [wormbase.db :as wdb]
    [wormbase.test-utils :as tu]
-   [wormbase.specs.gene :as wsg]
-   [clojure.string :as str])
+   [wormbase.specs.gene :as wsg])
   (:import
    (clojure.lang ExceptionInfo)))
 

--- a/test/wormbase/test_utils.clj
+++ b/test/wormbase/test_utils.clj
@@ -315,6 +315,12 @@
     (not (and (uniq-names? cgc-names)
               (uniq-names? seq-names)))))
 
+(defn gen-sample [data-gen n]
+  (->> (gen/sample data-gen n)
+       (map #(remove (comp nil? val) %))
+       (map #(into {} %))
+       (map #(dissoc % :history))))
+
 (defn gene-samples [n]
   (assert (int? n))
   (let [gene-refs (into {}
@@ -322,11 +328,10 @@
                                         [idx {:gene/id sample-id}])
                                       (gen/sample gsg/id n)))
         gene-recs (map (fn make-valid [m]
-                         (-> m
-                             (dissoc :history)
-                             (assoc :gene/cgc-name (cgc-name-for-sample m)
-                                    :gene/sequence-name (seq-name-for-sample m))))
-                       (gen/sample gsg/payload n))
+                         (assoc m
+                                :gene/cgc-name (cgc-name-for-sample m)
+                                :gene/sequence-name (seq-name-for-sample m)))
+                       (gen-sample gsg/payload n))
         data-samples (keep-indexed
                       (fn [i gr]
                         (merge (get gene-refs i) gr)) gene-recs)


### PR DESCRIPTION
@sibyl229,
Implements back-end changes required for #78.
Each entry in the `:history` of (ie.e for each gene event)  will have sub-structure under  a "changes" key,
that will be sequence of mappings with there keys: 
  1. attr : `string?`:  name of attrobute e.g "gene/cgc-name"
  2. value - `any?` : value of attr  (dependant on attr)
  3. added  - `boolean?` : whether this attr/value pair was added by the 
 
Example of the new structure that can be seen in the JSON:
```text
 {"provenance":
   {"changes":
     [{"attr": "attr-name-here", "value": "historical value", "added":
   true-or-false}, ...]}, ...],
    ...}
 ```
