### PR TITLE
Changes Table related work

### DIFF
--- a/client/src/components/elements/Page/index.js
+++ b/client/src/components/elements/Page/index.js
@@ -65,7 +65,7 @@ export const PageLeft = withStyles((theme) => ({
 
 export const PageMain = withStyles((theme) => ({
   main: {
-    width: '60%',
+    width: '80%',
     margin: `0px ${theme.spacing.unit * 4}px`,
     [theme.breakpoints.down('sm')]: {
       margin: 0,
@@ -74,13 +74,13 @@ export const PageMain = withStyles((theme) => ({
   },
 }))(pageMain);
 
-export const PageRight = withStyles((theme) => ({
-  right: {
-    width: '20%',
-    [theme.breakpoints.down('sm')]: {
-      width: `100%`,
-    },
-  },
-}))(pageRight);
+// export const PageRight = withStyles((theme) => ({
+//   right: {
+//     width: '20%',
+//     [theme.breakpoints.down('sm')]: {
+//       width: `100%`,
+//     },
+//   },
+// }))(pageRight);
 
 export default Page;

--- a/client/src/components/elements/Timestamp.js
+++ b/client/src/components/elements/Timestamp.js
@@ -1,11 +1,18 @@
 import React, { Component } from 'react';  // eslint-disable-line no-unused-vars
 import PropTypes from 'prop-types';
 import moment from 'moment';
+import { Tooltip } from '@material-ui/core';
 
 class Timestamp extends Component {
   render() {
     const {time} = this.props;
-    return moment(time).fromNow();
+    return (
+      <Tooltip title={time} placement="top-start">
+        <span>
+          {moment(time).fromNow()}
+        </span>
+      </Tooltip>
+    );
   }
 }
 

--- a/client/src/components/elements/index.js
+++ b/client/src/components/elements/index.js
@@ -20,6 +20,7 @@ export {
   DialogContent,
   DialogContentText,
   DialogTitle,
+  Divider,
   Icon,
   InputAdornment,
   MenuItem,
@@ -43,7 +44,7 @@ export { default as BaseForm } from './BaseForm';
 export { default as BiotypeSelect } from './BiotypeSelect';
 export { default as SimpleAjax } from './SimpleAjax';
 export { default as NotFound } from './NotFound';
-export { Page, PageLeft, PageMain, PageRight } from './Page';
+export { Page, PageLeft, PageMain } from './Page';
 export * from './ProgressButton';
 export { default as ProgressButton } from './ProgressButton';
 export { default as SimpleListPagination } from './SimpleListPagination';

--- a/client/src/containers/Footer.js
+++ b/client/src/containers/Footer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withStyles, colors } from '../components/elements'
+import { withStyles } from '../components/elements'
 
 const Footer = (props) => {
   const {classes} = props;

--- a/client/src/containers/Gene/GeneActivitiesTable.js
+++ b/client/src/containers/Gene/GeneActivitiesTable.js
@@ -146,9 +146,9 @@ class GeneActivitiesTable extends Component {
         </TableHead>
         <TableBody>
           {
-            Object.keys(changeLookup).map((attr) => {
+            Object.keys(changeLookup).map((attr, index) => {
               return (
-                <TableRow>
+                <TableRow key={index}>
                   <TableCell className={this.props.classes.changeTableCell}>
                     {attr}
                   </TableCell>

--- a/client/src/containers/Gene/GeneActivitiesTable.js
+++ b/client/src/containers/Gene/GeneActivitiesTable.js
@@ -4,12 +4,14 @@ import { Link } from 'react-router-dom';
 import {
   withStyles,
   Button,
+  Paper,
   Table,
   TableBody,
   TableCell,
   TableHead,
   TableRow,
   Timestamp,
+  Typography,
 } from '../../components/elements';
 import ResurrectGeneDialog from './ResurrectGeneDialog';
 import UndoMergeGeneDialog from './UndoMergeGeneDialog';
@@ -173,20 +175,8 @@ class GeneActivitiesTable extends Component {
     const selectedActivity = selectedActivityIndex !== null ? activities[selectedActivityIndex] : null;
 
     return (
-      <div>
+      <Paper>
         <Table>
-          <TableHead>
-            <TableRow>
-              <TableCell>Time</TableCell>
-              <TableCell className={classes.entityColumnHeader}>Entity</TableCell>
-              <TableCell>Event type</TableCell>
-              <TableCell>Related entity</TableCell>
-              <TableCell>Curated by</TableCell>
-              <TableCell>Reason</TableCell>
-              <TableCell>Agent</TableCell>
-              <TableCell></TableCell>
-            </TableRow>
-          </TableHead>
           <TableBody>
             {
               this.props.activities.map(
@@ -195,7 +185,10 @@ class GeneActivitiesTable extends Component {
                   return (
                     <TableRow key={activityIndex}>
                       <TableCell className={classes.time}>
-                        <Timestamp time={activityItem['provenance/when']}/>
+                        <p><Timestamp time={activityItem['provenance/when']}/></p>
+                        <em>{activityItem['provenance/who']['person/name']}</em>
+                        <span className={classes.via}> via </span>
+                        <em><Humanize>{activityItem['provenance/how']}</Humanize></em>
                       </TableCell>
                       <TableCell className={classes.entityCell}>
                         {
@@ -205,31 +198,30 @@ class GeneActivitiesTable extends Component {
                         }
                       </TableCell>
                       <TableCell className={classes.eventCell}>
-                        <span className={classes.eventLabel}><Humanize>{eventLabel}</Humanize></span>
+                        <Typography gutterBottom className={classes.eventLabel}>
+                          <span><Humanize>{eventLabel}</Humanize> </span>
+                          {
+                            relatedEntity ?
+                              <Link to={`/gene/id/${relatedEntity['gene/id']}`}>{relatedEntity['gene/id']}</Link> :
+                              null
+                          }
+                        </Typography>
+                        {
+                          activityItem['provenance/why'] &&
+                          <Typography gutterBottom>
+                            <span className={classes.reason}>Reason:</span> <em>{activityItem['provenance/why']}</em>
+                          </Typography>
+                        }
                         {this.renderChanges(activityItem.changes)}
                       </TableCell>
-                      <TableCell>
+                      {/* <TableCell>
                         {
-                          relatedEntity ?
-                            <Link to={`/gene/id/${relatedEntity['gene/id']}`}>{relatedEntity['gene/id']}</Link> :
-                            null
+                          this.renderActions({
+                            ...activityItem,
+                            activityIndex,
+                          })
                         }
-                      </TableCell>
-                      <TableCell>{activityItem['provenance/who']['person/name']}</TableCell>
-                      <TableCell>{activityItem['provenance/why']}</TableCell>
-                      <TableCell>
-                        <Humanize>
-                          {activityItem['provenance/how']}
-                        </Humanize>
-                      </TableCell>
-                      <TableCell>
-                        {
-                          // this.renderActions({
-                          //   ...activityItem,
-                          //   activityIndex,
-                          // })
-                        }
-                      </TableCell>
+                      </TableCell> */}
                     </TableRow>
                   )
                 }
@@ -276,7 +268,7 @@ class GeneActivitiesTable extends Component {
             }}
           />
         </div>
-      </div>
+      </Paper>
     );
   }
 }
@@ -302,11 +294,18 @@ const styles = (theme) => ({
   eventCell: {
   },
   eventLabel: {
-    lineHeight: '1.5em',
-    fontStyle: 'italic',
+    textTransform: 'capitalize',
+    // fontStyle: 'italic',
   },
   changeTable: {
     backgroundColor: theme.palette.background.default,
+  },
+  via: {
+    color: theme.palette.text.secondary,
+  },
+  reason: {
+    color: theme.palette.text.secondary,
+    fontStyle: 'normal',
   },
   changeTableCell: {
     border: 'none',

--- a/client/src/containers/Gene/GeneActivitiesTable.js
+++ b/client/src/containers/Gene/GeneActivitiesTable.js
@@ -120,6 +120,10 @@ class GeneActivitiesTable extends Component {
   }
 
   renderChanges = (changes) => {
+    if (!changes || changes.length === 0) {
+      return null;
+    }
+
     const changeLookup = changes.reduce((result, changeEntry) => {
       const changeSumamry = {
         ...result[changeEntry.attr],

--- a/client/src/containers/Gene/GeneActivitiesTable.js
+++ b/client/src/containers/Gene/GeneActivitiesTable.js
@@ -175,7 +175,7 @@ class GeneActivitiesTable extends Component {
     const selectedActivity = selectedActivityIndex !== null ? activities[selectedActivityIndex] : null;
 
     return (
-      <Paper>
+      <Paper className={classes.root}>
         <Table>
           <TableBody>
             {
@@ -288,6 +288,9 @@ GeneActivitiesTable.defaultProps = {
 const styles = (theme) => ({
   time: {
     whiteSpace: 'nowrap',
+  },
+  root: {
+    overflow: 'scroll',
   },
   entityColumnHeader: {},
   entityCell: {},

--- a/client/src/containers/Gene/GeneCreate.js
+++ b/client/src/containers/Gene/GeneCreate.js
@@ -9,6 +9,7 @@ import {
   PageMain,
   Typography,
   ValidationError,
+  withStyles,
 } from '../../components/elements';
 import GeneForm from './GeneForm';
 
@@ -97,6 +98,7 @@ class GeneCreate extends Component {
           <Button
             variant="raised"
             component={({...props}) => <Link to='/gene' {...props} />}
+            className={this.props.classes.backToDirectoryButton}
           >
             Back to directory
           </Button>
@@ -123,4 +125,13 @@ GeneCreate.propTypes = {
   authorizedFetch: PropTypes.func.isRequired,
 };
 
-export default withRouter(GeneCreate);
+const styles = (theme) => ({
+  backToDirectoryButton: {
+    width: 150,
+    [theme.breakpoints.down('sm')]: {
+      width: '100%',
+    },
+  },
+});
+
+export default withStyles(styles)(withRouter(GeneCreate));

--- a/client/src/containers/Gene/GeneProfile.js
+++ b/client/src/containers/Gene/GeneProfile.js
@@ -6,12 +6,12 @@ import {
   withStyles,
   Button,
   CircularProgress,
+  Divider,
   Humanize,
   NotFound,
   Page,
   PageLeft,
   PageMain,
-  PageRight,
   Snackbar,
   SnackbarContent,
   Typography,
@@ -319,45 +319,10 @@ class GeneProfile extends Component {
     ) : (
       <Page>
         <PageLeft>
-          {backToDirectoryButton}
-        </PageLeft>
-        <PageMain>
-          <Typography variant="headline" gutterBottom>Gene <em>{wbId}</em></Typography>
-          <ValidationError {...this.state.errorMessage} />
-          {
-            this.state.status === 'LOADING' ?
-              <CircularProgress /> :
-              <div>
-                {
-                  this.state.data['gene/status'] !== 'gene.status/live' ?
-                    <Typography variant="display1" gutterBottom>
-                      <Humanize>{this.state.data['gene/status']}</Humanize>
-                    </Typography> :
-                    null
-                }
-                <GeneForm
-                  data={this.state.data}
-                  onSubmit={this.handleGeneUpdate}
-                  submitted={this.state.status === 'SUBMITTED'}
-                  disabled={Boolean(this.state.data['gene/status'] === 'gene.status/dead')}
-                />
-              </div>
-          }
-          <div className={classes.section}>
-            <Typography variant="title" gutterBottom>Change history</Typography>
-            <div className={classes.historyTable}>
-              <RecentActivitiesSingleGene
-                wbId={wbId}
-                authorizedFetch={this.props.authorizedFetch}
-                activities={this.state.data.history}
-                onUpdate={() => {
-                  this.fetchData();
-                }}
-              />
-            </div>
+          <div className={classes.operations}>
+            {backToDirectoryButton}
+            <Divider light />
           </div>
-        </PageMain>
-        <PageRight>
           {
             this.state.data['gene/status'] === 'gene.status/live' ?
               <div className={classes.operations}>
@@ -404,7 +369,44 @@ class GeneProfile extends Component {
                 >Resurrect Gene</Button>
               </div> : null
           }
-        </PageRight>
+        </PageLeft>
+        <PageMain>
+          <Typography variant="headline" gutterBottom>Gene <em>{wbId}</em></Typography>
+          <ValidationError {...this.state.errorMessage} />
+          {
+            this.state.status === 'LOADING' ?
+              <CircularProgress /> :
+              <div>
+                {
+                  this.state.data['gene/status'] !== 'gene.status/live' ?
+                    <Typography variant="display1" gutterBottom>
+                      <Humanize>{this.state.data['gene/status']}</Humanize>
+                    </Typography> :
+                    null
+                }
+                <GeneForm
+                  data={this.state.data}
+                  onSubmit={this.handleGeneUpdate}
+                  submitted={this.state.status === 'SUBMITTED'}
+                  disabled={Boolean(this.state.data['gene/status'] === 'gene.status/dead')}
+                />
+              </div>
+          }
+          <div className={classes.section}>
+            <Typography variant="title" gutterBottom>Change history</Typography>
+            <div className={classes.historyTable}>
+              <RecentActivitiesSingleGene
+                wbId={wbId}
+                authorizedFetch={this.props.authorizedFetch}
+                activities={this.state.data.history}
+                onUpdate={() => {
+                  this.fetchData();
+                }}
+              />
+            </div>
+          </div>
+        </PageMain>
+
         <KillGeneDialog
           geneName={this.getDisplayName(this.state.data)}
           wbId={wbId}
@@ -516,9 +518,13 @@ const styles = (theme) => ({
   operations: {
     display: 'flex',
     flexDirection: 'column',
-    maxWidth: 150,
+    width: 150,
     '& > *': {
       marginBottom: theme.spacing.unit,
+    },
+    [theme.breakpoints.down('sm')]: {
+      width: '100%',
+      alignItems: 'stretch',
     },
   },
   killButton: {

--- a/client/src/containers/Gene/GeneProfile.js
+++ b/client/src/containers/Gene/GeneProfile.js
@@ -395,14 +395,14 @@ class GeneProfile extends Component {
                 >Kill Gene</Button>
                 <h5>Tips:</h5>
                 <p>To un-suppress the gene, kill then resurrect it.</p>
-              </div> :
+              </div> : this.state.data['gene/status'] === 'gene.status/dead' ?
               <div className={classes.operations}>
                 <Button
                   className={classes.killButton}
                   variant="raised"
                   onClick={this.openResurrectGeneDialog}
                 >Resurrect Gene</Button>
-              </div>
+              </div> : null
           }
         </PageRight>
         <KillGeneDialog

--- a/client/src/containers/Gene/GeneProfile.js
+++ b/client/src/containers/Gene/GeneProfile.js
@@ -532,9 +532,6 @@ const styles = (theme) => ({
     margin: `${theme.spacing.unit * 8}px 0`,
   },
   historyTable: {
-    [theme.breakpoints.down('sm')]: {
-      overflow: 'scroll',
-    },
   },
 });
 


### PR DESCRIPTION
- not render change table when :changes is false-y or empty (fixes #101)

- make changes table more compact, by merging a few columns:
![screen shot 2018-09-26 at 3 33 15 pm](https://user-images.githubusercontent.com/1753893/46104516-83cdd400-c1a1-11e8-9afe-5ecad1503e24.png)

- remove right sidebar, and merge its content with the left one, to make room for the main panel (which holds the history table)
![screen shot 2018-09-26 at 3 37 50 pm](https://user-images.githubusercontent.com/1753893/46104760-2dad6080-c1a2-11e8-9117-df6028326bf9.png)
