### PR TITLE
fix activities display for merge and split events after refactoring

### DIFF
--- a/client/src/containers/Gene/GeneActivitiesTable.js
+++ b/client/src/containers/Gene/GeneActivitiesTable.js
@@ -83,26 +83,19 @@ class GeneActivitiesTable extends Component {
     const { statusChange, relatedGeneId } = (activityItem.changes || []).reduce(
       (result, change) => {
         const { attr, value, added } = change || {};
-        if (attr === 'gene/merges' && added) {
-          return {
-            ...result,
-            relatedGeneId: value,
-          };
-        } else if (attr === 'gene/splits' && added) {
-          return {
-            ...result,
-            relatedGeneId: value,
-          };
-        } else if (attr === 'gene/status' && added) {
-          return {
-            ...result,
-            statusChange: value,
-          };
-        } else {
-          return {
-            ...result,
-          };
-        }
+        if (added)
+          if (attr === 'gene/splits' || attr === 'gene/merges') {
+            return {
+              ...result,
+              relatedGeneId: value,
+            };
+          } else if (attr === 'gene/status') {
+            return {
+              ...result,
+              statusChange: value,
+            };
+          }
+        return result;
       },
       {}
     );


### PR DESCRIPTION
fixes #148 

Can I assume the changes on the "split into gene" will include the following? (I can't test this yet, due to #153)
```
{ attr: 'gene/status', value: 'gene.status/live', added: 'true' }
```