### PR TITLE
past tense for event label

### DIFF
--- a/client/src/components/elements/Humanize.js
+++ b/client/src/components/elements/Humanize.js
@@ -1,13 +1,18 @@
 import PropTypes from 'prop-types';
 
-const Humanize = ({ children, placeholder = 'Unknown' }) => {
+const Humanize = ({ children, placeholder = 'Unknown', postProcessor }) => {
+  if (!children) {
+    return placeholder;
+  }
   const [name] = (children || '').split('/').slice(-1);
-  return name.replace(/(_|-)+/g, ' ') || placeholder;
+  const humanizedText = name.replace(/(_|-)+/g, ' ');
+  return postProcessor ? postProcessor(humanizedText) : humanizedText;
 };
 
 Humanize.propTypes = {
   children: PropTypes.string,
   placeholder: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
+  postProcessor: PropTypes.func,
 };
 
 export default Humanize;

--- a/client/src/components/elements/Humanize.js
+++ b/client/src/components/elements/Humanize.js
@@ -1,16 +1,32 @@
 import PropTypes from 'prop-types';
 
-const Humanize = ({ children, placeholder = 'Unknown', postProcessor }) => {
+const Humanize = ({
+  children,
+  placeholder = 'Unknown',
+  postProcessor,
+  capitalize = false,
+}) => {
   if (!children) {
     return placeholder;
   }
-  const [name] = (children || '').split('/').slice(-1);
-  const humanizedText = name.replace(/(_|-)+/g, ' ');
-  return postProcessor ? postProcessor(humanizedText) : humanizedText;
+  let [humanizedText] = (children || '').split('/').slice(-1);
+  humanizedText = humanizedText.replace(/(_|-)+/g, ' ');
+
+  if (capitalize) {
+    humanizedText =
+      humanizedText.charAt(0).toUpperCase() + humanizedText.slice(1);
+  }
+
+  if (postProcessor) {
+    humanizedText = postProcessor(humanizedText);
+  }
+
+  return humanizedText;
 };
 
 Humanize.propTypes = {
   children: PropTypes.string,
+  capitalize: PropTypes.bool,
   placeholder: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
   postProcessor: PropTypes.func,
 };

--- a/client/src/containers/Gene/GeneActivitiesTable.js
+++ b/client/src/containers/Gene/GeneActivitiesTable.js
@@ -14,6 +14,7 @@ import {
   Timestamp,
   Typography,
 } from '../../components/elements';
+import { pastTense } from '../../utils/events';
 import ResurrectGeneDialog from './ResurrectGeneDialog';
 import UndoMergeGeneDialog from './UndoMergeGeneDialog';
 import UndoSplitGeneDialog from './UndoSplitGeneDialog';
@@ -234,7 +235,9 @@ class GeneActivitiesTable extends Component {
                   <TableCell className={classes.eventCell}>
                     <Typography gutterBottom className={classes.eventLabel}>
                       <span>
-                        <Humanize>{eventLabel}</Humanize>{' '}
+                        <Humanize postProcessor={pastTense}>
+                          {eventLabel}
+                        </Humanize>{' '}
                       </span>
                       {relatedEntity ? (
                         <Link to={`/gene/id/${relatedEntity['gene/id']}`}>

--- a/client/src/containers/Gene/GeneActivitiesTable.js
+++ b/client/src/containers/Gene/GeneActivitiesTable.js
@@ -14,7 +14,7 @@ import {
   Timestamp,
   Typography,
 } from '../../components/elements';
-import { pastTense } from '../../utils/events';
+import { pastTense, getActivityDescriptor } from '../../utils/events';
 import ResurrectGeneDialog from './ResurrectGeneDialog';
 import UndoMergeGeneDialog from './UndoMergeGeneDialog';
 import UndoSplitGeneDialog from './UndoSplitGeneDialog';
@@ -77,61 +77,6 @@ class GeneActivitiesTable extends Component {
         ) : null}
       </div>
     );
-  };
-
-  getActivityDescriptor = (activityItem = {}, selfGeneId) => {
-    const what = activityItem['provenance/what'];
-    const { statusChange, relatedGeneId } = (activityItem.changes || []).reduce(
-      (result, change) => {
-        const { attr, value, added } = change || {};
-        if (added)
-          if (attr === 'gene/splits' || attr === 'gene/merges') {
-            return {
-              ...result,
-              relatedGeneId: value,
-            };
-          } else if (attr === 'gene/status') {
-            return {
-              ...result,
-              statusChange: value,
-            };
-          }
-        return result;
-      },
-      {}
-    );
-
-    let eventType;
-    if (what === 'event/merge-genes' && !statusChange) {
-      eventType = 'merge_from';
-    } else if (
-      what === 'event/merge-genes' &&
-      statusChange === 'gene.status/dead'
-    ) {
-      eventType = 'merge_into';
-    } else if (what === 'event/split-gene' && !statusChange) {
-      eventType = 'split_into';
-    } else if (
-      what === 'event/split-gene' &&
-      statusChange === 'gene.status/live'
-    ) {
-      eventType = 'split_from';
-    } else {
-      eventType = what;
-    }
-
-    const descriptor = {
-      eventLabel: eventType || activityItem['provenance/what'],
-      entity: {
-        'gene/id': selfGeneId,
-      },
-      relatedEntity: relatedGeneId
-        ? {
-            'gene/id': relatedGeneId,
-          }
-        : null,
-    };
-    return descriptor;
   };
 
   getGeneIdForEvent = (selectedActivity, eventType) => {
@@ -205,10 +150,7 @@ class GeneActivitiesTable extends Component {
                 eventLabel,
                 entity,
                 relatedEntity,
-              } = this.getActivityDescriptor(
-                activityItem,
-                this.props.selfGeneId
-              );
+              } = getActivityDescriptor(activityItem, this.props.selfGeneId);
               return (
                 <TableRow key={activityIndex}>
                   <TableCell className={classes.time}>

--- a/client/src/containers/Gene/GeneProfile.js
+++ b/client/src/containers/Gene/GeneProfile.js
@@ -402,7 +402,9 @@ class GeneProfile extends Component {
             <div>
               {this.state.data['gene/status'] !== 'gene.status/live' ? (
                 <Typography variant="display1" gutterBottom>
-                  <Humanize>{this.state.data['gene/status']}</Humanize>
+                  <Humanize capitalize>
+                    {this.state.data['gene/status']}
+                  </Humanize>
                   {this.state.data['gene/status'] === 'gene.status/dead' ? (
                     <Typography variant="subheading" component={'i'}>
                       (

--- a/client/src/containers/Gene/GeneProfile.js
+++ b/client/src/containers/Gene/GeneProfile.js
@@ -18,6 +18,7 @@ import {
   Typography,
   ValidationError,
 } from '../../components/elements';
+import { pastTense, getActivityDescriptor } from '../../utils/events';
 import GeneForm from './GeneForm';
 import KillGeneDialog from './KillGeneDialog';
 import ResurrectGeneDialog from './ResurrectGeneDialog';
@@ -313,6 +314,10 @@ class GeneProfile extends Component {
         Back to directory
       </Button>
     );
+    const killEventDescriptor =
+      this.state.data['gene/status'] === 'gene.status/dead'
+        ? getActivityDescriptor(this.state.data.history[0])
+        : {};
 
     return this.state.status === 'NOT_FOUND' ? (
       <NotFound>
@@ -398,6 +403,27 @@ class GeneProfile extends Component {
               {this.state.data['gene/status'] !== 'gene.status/live' ? (
                 <Typography variant="display1" gutterBottom>
                   <Humanize>{this.state.data['gene/status']}</Humanize>
+                  {this.state.data['gene/status'] === 'gene.status/dead' ? (
+                    <Typography variant="subheading" component={'i'}>
+                      (
+                      <Humanize postProcessor={pastTense}>
+                        {killEventDescriptor.eventLabel}
+                      </Humanize>
+                      {killEventDescriptor.relatedEntity ? (
+                        <React.Fragment>
+                          {' '}
+                          <Link
+                            to={`/gene/id/${
+                              killEventDescriptor.relatedEntity['gene/id']
+                            }`}
+                          >
+                            {killEventDescriptor.relatedEntity['gene/id']}
+                          </Link>
+                        </React.Fragment>
+                      ) : null}
+                      )
+                    </Typography>
+                  ) : null}
                 </Typography>
               ) : null}
               <ErrorBoundary>

--- a/client/src/utils/events.js
+++ b/client/src/utils/events.js
@@ -1,3 +1,59 @@
 export function pastTense(eventText = '') {
   return eventText.replace(/(merg|kill|resurrect|suppress)e?/g, '$1ed');
 }
+
+export function getActivityDescriptor(activityItem = {}, selfGeneId) {
+  const what = activityItem['provenance/what'];
+  const { statusChange, relatedGeneId } = (activityItem.changes || []).reduce(
+    (result, change) => {
+      const { attr, value, added } = change || {};
+      if (added)
+        if (attr === 'gene/splits' || attr === 'gene/merges') {
+          return {
+            ...result,
+            relatedGeneId: value,
+          };
+        } else if (attr === 'gene/status') {
+          return {
+            ...result,
+            statusChange: value,
+          };
+        }
+      return result;
+    },
+    {}
+  );
+
+  let eventType;
+  if (what === 'event/merge-genes' && !statusChange) {
+    eventType = 'merge_from';
+  } else if (
+    what === 'event/merge-genes' &&
+    statusChange === 'gene.status/dead'
+  ) {
+    eventType = 'merge_into';
+  } else if (what === 'event/split-gene' && !statusChange) {
+    eventType = 'split_into';
+  } else if (
+    what === 'event/split-gene' &&
+    statusChange === 'gene.status/live'
+  ) {
+    eventType = 'split_from';
+  } else {
+    eventType = what.replace(/-gene/, '').trim();
+    console.log(eventType);
+  }
+
+  const descriptor = {
+    eventLabel: eventType || activityItem['provenance/what'],
+    entity: {
+      'gene/id': selfGeneId,
+    },
+    relatedEntity: relatedGeneId
+      ? {
+          'gene/id': relatedGeneId,
+        }
+      : null,
+  };
+  return descriptor;
+}

--- a/client/src/utils/events.js
+++ b/client/src/utils/events.js
@@ -1,0 +1,3 @@
+export function pastTense(eventText = '') {
+  return eventText.replace(/(merg|kill|resurrect|suppress)e?/g, '$1ed');
+}


### PR DESCRIPTION
- use past tense when displaying event in history/activities table (fixes #155)
- for dead gene, display the most recent event by the status