### PR TITLE
Reworked gene summary provenance changes.

### DIFF
--- a/src/wormbase/names/importers/gene.clj
+++ b/src/wormbase/names/importers/gene.clj
@@ -178,7 +178,7 @@
   \"imported\" more than once (data fudging)."
   [events]
   (->> (filter #(= (:provenance/what %) :event/new-gene) events)
-       wnp/sort-events-by-when
+       (wnp/sort-events-by :provenance/when)
        last))
 
 (defn process-gene-events [[gid events]]
@@ -191,7 +191,7 @@
         fixedup-events (if first-created
                          (conj no-created first-created)
                          no-created)]
-    [gid (wnp/sort-events-by-when fixedup-events)]))
+    [gid (wnp/sort-events-by :provenance/when fixedup-events)]))
 
 (defn map-history-actions [tsv-path]
   (let [ev-ex-conf (:events export-conf)

--- a/src/wormbase/names/person.clj
+++ b/src/wormbase/names/person.clj
@@ -19,7 +19,9 @@
 (defmethod wnp/resolve-change :person/id
   [attr db change]
   (when-let [found (wnu/resolve-refs db (find change :person/id))]
-    (:person/id found)))
+    (assoc change
+           :value
+           (:person/id found))))
 
 (defn create-person [request]
   (admin-required request)

--- a/src/wormbase/specs/gene.clj
+++ b/src/wormbase/specs/gene.clj
@@ -93,13 +93,13 @@
 (s/def ::added sts/boolean?)
 (s/def ::change (s/keys :req-un [::attr ::value ::added]))
 (s/def ::changes (s/coll-of ::change))
-(s/def ::provenance (s/merge ::wsp/provenance (s/keys :req-un [::changes])))
+(s/def ::provenance (s/merge ::wsp/provenance (s/keys :req-un [::changes ::wsp/t])))
 (s/def ::history (stc/spec
                   (s/coll-of ::provenance :type vector? :min-count 1)))
 
-(s/def ::info (stc/spec (s/or :cloned ::cloned
-                              :uncloned ::uncloned
-                              :anonymous ::anonymous)))
+(s/def ::summary (stc/spec (s/or :cloned ::cloned
+                                 :uncloned ::uncloned
+                                 :anonymous ::anonymous)))
 
 (s/def ::identifier (stc/spec (s/or :gene/id :gene/id
                                     :gene/cgc-name :gene/cgc-name

--- a/src/wormbase/specs/provenance.clj
+++ b/src/wormbase/specs/provenance.clj
@@ -9,6 +9,7 @@
 
 ;; TODO: clients should provide zoned-date-time (times in UTC)
 ;;       - db wants instants (java.utl.Date values)
+(s/def ::t sts/inst?)
 
 (s/def :provenance/when sts/inst?)
 

--- a/test/integration/test_merge_genes.clj
+++ b/test/integration/test_merge_genes.clj
@@ -147,7 +147,10 @@
                       {:provenance/what [:db/ident]
                        :provenance/who [:person/email :person/name :person/id]
                        :provenance/how [:db/ident]}]
-                prov (some->> (wnp/query-provenance (d/db conn) [:gene/id from-id] ppe)
+                prov (some->> (wnp/query-provenance (d/db conn)
+                                                    (d/log conn)
+                                                    [:gene/id from-id]
+                                                    ppe)
                               (filter #(= (:provenance/what %) :event/merge-genes))
                               first)]
             (tu/status-is? (:status (ok)) status body)

--- a/test/wormbase/gen_specs/gene.clj
+++ b/test/wormbase/gen_specs/gene.clj
@@ -77,7 +77,7 @@
    :gene/status (constantly status)
    :gene/sequence-name (constantly sequence-name)})
 
-(def info (s/gen ::wsg/info overrides))
+(def summary (s/gen ::wsg/summary overrides))
 
 (def cloned (s/gen ::wsg/cloned overrides))
 


### PR DESCRIPTION
Broken by an earlier refactoring.

Added a new attribute `:t` for each item in the `:history` collection
returned in the summary; this is wall clock time of the transaction (txInstant).

Use the Datomic Log API in conjunction with the `tx-data` datalog fn
to efficiently retrieve change attributes for a given transaction.

Updated tests that use the query-provenance API to use the new
signature.

Renamed the registered name of the spec used to describe the gene
summary response.

Fixes #185