### PR TITLE
Fix/login

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13978,6 +13978,11 @@
         "shallowequal": "^1.0.1"
       }
     },
+    "react-storage-hooks": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/react-storage-hooks/-/react-storage-hooks-3.0.1.tgz",
+      "integrity": "sha512-Jt5AeiRhzgG5DK97XILc6fsxGhSAdmkfhgNS2a3QyJCdLgSOMXtChvqPEHYcioUrOXE5Npj9xVnoGb2H6DZXDA=="
+    },
     "react-transition-group": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -26,6 +26,7 @@
     "react-document-title": "2.0.3",
     "react-dom": "16.8.5",
     "react-router-dom": "5.0.0",
+    "react-storage-hooks": "3.0.1",
     "redux": "4.0.0",
     "typeface-roboto": "0.0.54"
   },

--- a/client/src/containers/Authenticate/index.js
+++ b/client/src/containers/Authenticate/index.js
@@ -1,10 +1,11 @@
 import React, {
   useMemo,
   useRef,
-  useReducer,
+  //  useReducer,
   useCallback,
   useEffect,
 } from 'react';
+import { useSessionStorageReducer } from 'react-storage-hooks';
 import Login from './Login';
 import Logout from './Logout';
 import Profile from './Profile';
@@ -15,9 +16,13 @@ import AuthorizationContext, {
 } from './AuthorizationContext';
 
 export default function Authenticate({ children }) {
-  const [state, dispatch] = useReducer(reducer, {
-    ...DEFAULT_AUTHENTICATION_STATE,
-  });
+  const [state, dispatch] = useSessionStorageReducer(
+    'authentication',
+    reducer,
+    {
+      ...DEFAULT_AUTHENTICATION_STATE,
+    }
+  );
 
   function reducer(state, { type, payload }) {
     switch (type) {


### PR DESCRIPTION
#282 

- Verify backend API accepts the id_token before consider a user authenticated
- Display error for login failure, when API response fails to accept the id_token
- Persist authentication related state in session storage, so that page refresh wouldn't require re-authentication.