### PR TITLE
Feature/phrase spec errors

### DIFF
--- a/client/src/components/elements/ValidationError.js
+++ b/client/src/components/elements/ValidationError.js
@@ -42,12 +42,26 @@ class ValidationError extends React.Component {
   };
 
   render() {
-    const { classes, message, problems } = this.props;
+    const { classes, message, problems, errors = [] } = this.props;
     const problemText = problems;
     return message || problems ? (
       <Card card className={classes.root}>
         <CardContent>
           <Typography color="error">{message || 'Error'}</Typography>
+          {errors.map(({ name, value, reason, regexp }) => (
+            <ul>
+              <li>
+                <Typography key={name} color="error">
+                  {name}:{' '}
+                  <em>
+                    <strong>{value}</strong>
+                  </em>{' '}
+                  {reason}
+                  {regexp ? <pre> {regexp}</pre> : null}
+                </Typography>
+              </li>
+            </ul>
+          ))}
         </CardContent>
         {this.renderActions()}
         <Collapse in={this.state.expanded}>
@@ -61,6 +75,16 @@ class ValidationError extends React.Component {
 }
 
 ValidationError.propTypes = {
+  classes: PropTypes.object.isRequired,
+  message: PropTypes.string,
+  errors: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string,
+      value: PropTypes.string,
+      reason: PropTypes.string,
+      regexp: PropTypes.string,
+    })
+  ),
   problems: PropTypes.object,
 };
 

--- a/deps.edn
+++ b/deps.edn
@@ -31,6 +31,7 @@
   metosin/muuntaja {:mvn/version "0.6.5"}
   ikitommi/linked {:mvn/version "1.3.1-alpha1"}
   mount {:mvn/version "0.1.16"}
+  phrase {:mvn/version "0.3-alpha4"}
   ring/ring-codec {:mvn/version "1.1.2"}
   ring/ring-defaults {:mvn/version "0.3.2"}
   ring/ring-jetty-adapter {:mvn/version "1.7.1"}

--- a/src/wormbase/names/entity.clj
+++ b/src/wormbase/names/entity.clj
@@ -44,7 +44,9 @@
         (when (:wormbase.names/name-required? ident-ent)
           (when-not (and name-val (s/valid? ::wse/name name-val))
             [{:name "name"
-              :value name-val}]))))))
+              :value name-val
+              :reason (format "%s name was blank or otherwise invalid."
+                              (str/capitalize ent-ns))}]))))))
 
 (defn transform-ident-ref-values
   [data & {:keys [skip-keys]
@@ -114,9 +116,9 @@
                    (transform-ident-ref-values)
                    (update live-status-attr (fnil identity live-status-val)))]
       (when-let [errors (names-validator data)]
-        (throw (ex-info "One ore missing or invalid names found"
+        (throw (ex-info "Missing or invalid name(s)."
                         (merge {:type :user/validation-error}
-                               errors))))
+                               {:errors errors}))))
       (let [cdata (prepare-data-for-transact db (wnu/qualify-keys data ent-ns))
             prov (wnp/assoc-provenance request payload event)
             tx-data [['wormbase.ids.core/new template uiident [cdata]] prov]

--- a/src/wormbase/names/entity.clj
+++ b/src/wormbase/names/entity.clj
@@ -125,7 +125,13 @@
         (when dba
           (let [new-id (wdb/extract-id tx-res uiident)
                 emap (wdb/pull dba summary-pull-expr [uiident new-id])
-                result {:created (wnu/unqualify-keys emap ent-ns)}]
+                emap* (reduce-kv (fn [m k v]
+                                   (if (qualified-keyword? v)
+                                     (assoc m k (name v))
+                                     (assoc m k v)))
+                                 {}
+                                 emap)
+                result {:created (wnu/unqualify-keys emap* ent-ns)}]
             (created (str "/" ent-ns "/") result)))))))
 
 (defn merge-into-ent-data

--- a/src/wormbase/names/gene.clj
+++ b/src/wormbase/names/gene.clj
@@ -59,14 +59,15 @@
       (let [patterns ((juxt :species/cgc-name-pattern :species/sequence-name-pattern) species-ent)
             regexps (map re-pattern patterns)
             name-idents [:gene/cgc-name :gene/sequence-name]]
-        (->> (partition 2 (interleave regexps name-idents))
+        (->> (interleave regexps name-idents)
+             (partition 2)
              (map (fn collect-errors [[regexp name-ident]]
                     (when-let [gname (name-ident data)]
                       (when-not (re-matches regexp gname)
-                        (when-not (and (empty? (get data gname))
-                                       (= gname :gene/cgc-name))
                           {:name (name name-ident)
-                           :value gname})))))
+                           :value gname
+                           :reason "Did not match species regular expression pattern."
+                           :regexp (str regexp)}))))
              (filter identity)
              (seq))))))
 

--- a/src/wormbase/names/gene.clj
+++ b/src/wormbase/names/gene.clj
@@ -54,8 +54,7 @@
                         {:type :user/validation-error})))
       (if-not (:db/id species-ent)
         (throw (ex-info "Invalid species specified"
-                        {:errors {:species (second species-lur)}
-                         :type :user/validation-error})))
+                        {:type :user/validation-error})))
       (let [patterns ((juxt :species/cgc-name-pattern :species/sequence-name-pattern) species-ent)
             regexps (map re-pattern patterns)
             name-idents [:gene/cgc-name :gene/sequence-name]]

--- a/src/wormbase/specs/biotype.clj
+++ b/src/wormbase/specs/biotype.clj
@@ -4,6 +4,6 @@
    [spec-tools.core :as stc]
    [spec-tools.spec :as sts]))
 
-(s/def ::identifier (stc/spec {:spec string?}))
+(s/def ::identifier (stc/spec {:spec (s/and string? not-empty)}))
 
   

--- a/src/wormbase/specs/gene.clj
+++ b/src/wormbase/specs/gene.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.string :as str]
    [clojure.spec.alpha :as s]
+   [phrase.alpha :as ph]
    [spec-tools.core :as stc]
    [spec-tools.spec :as sts]
    [wormbase.specs.biotype :as wsb]
@@ -56,11 +57,26 @@
                             :opt-un [:gene/species
                                      :gene/status]))))
 
-(s/def ::new (stc/spec {:spec (s/or :cloned ::cloned
-                                    :uncloned ::uncloned)
+(def not-empty? #(not (empty? %)))
+
+(s/def ::new (stc/spec {:spec (s/and not-empty?
+                                     (s/or :cloned ::cloned
+                                           :uncloned ::uncloned))
                         :description (str "The data required to populate a new Gene. "
                                           "This data should be in one two forms: cloned, or "
                                           "uncloned.")}))
+(ph/defphraser not-empty
+  [_ problem]
+  (str (-> problem :via last keyword name) " must not be blank."))
+
+(ph/defphraser not-empty?
+  [_ problems]
+  (str "A new gene requires at least a species and a name."))
+
+;; (ph/defphraser #(contains? % :cgc-name) [_ _] "cgc-name is required")
+;; (ph/defphraser #(contains? % :sequence-name) [_ _] "sequence-name is required")
+;; (ph/defphraser #(contains? % :biotype) [_ _] "biotype is required")
+
 
 (s/def ::new-unnamed (s/keys :req-un [:gene/id
                                       :gene/species]))

--- a/src/wormbase/specs/species.clj
+++ b/src/wormbase/specs/species.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.spec.alpha :as s]
    [clojure.string :as str]
+   [phrase.alpha :as ph]
    [spec-tools.core :as stc]
    [spec-tools.spec :as sts]
    [wormbase.specs.provenance :as wsp]))
@@ -16,21 +17,35 @@
 (s/def :species/sequence-name-pattern (s/and string?
                                              (complement str/blank?)))
 
-(s/def :species/id (stc/spec {:spec (s/and string?
-                                           #(re-matches id-regexp %))
+(def matches-id-regexp (partial re-matches id-regexp))
+
+(s/def :species/id (stc/spec {:spec (s/and string? matches-id-regexp)
                               :swagger/example "species/c-elegans"
                               :description "The identifier for a species."}))
+
+(ph/defphraser matches-id-regexp [_ _] "Species ID must match regular expression.")
 
 (s/def ::species-id-name (stc/spec {:spec (s/and string?
                                                  #(str/includes? % "-"))
                                     :swagger/example "c-elegans"
                                     :description "The short-name of the id."}))
 
-(s/def :species/latin-name (stc/spec {:spec (s/and sts/string? #(re-matches latin-name-regexp %))
+(def matches-latin-name-regexp (partial re-matches latin-name-regexp))
+
+(s/def :species/latin-name (stc/spec {:spec (s/and sts/string? matches-latin-name-regexp)
                                       :description "The linnaean name of the species."}))
+
+(ph/defphraser matches-latin-name-regexp
+  [_ problem]
+  "Species name must match regular expression.")
+
 
 (s/def ::identifier (stc/spec {:spec (s/or :species/id :species/id
                                            :species/latin-name :species/latin-name)}))
+
+(ph/defphraser :species/latin-name
+  [_ problem]
+  "Species name must match regular expression.")
 
 (s/def ::item (s/keys :req-un [:species/id
                                :species/latin-name


### PR DESCRIPTION
Provides:
 - human readable error message when a validation error occurs (HTTP 400 responses).
 - display "primary ID" (i.e WB* ids)  upon db conflict (.eg "$name already stored against $wbid)
 
cases tested (manually)
 -  gene create
 -  var create
 -  strain create

Error messages  `clojure.spec` failures are translated to human readable messages using the [phrase][1] library. 
The top level response body should contain `{"message": "...", ...}`
Species specific name validation occurs later in the processing phase, and are not implemented using `clojure.spec`,  and return a more verbose form,
containing specific error messages for each field that failed name validation.
```json
{"message": "<top level message here>",
 "type": "...",
 "errors": [{"message": "...."}, ...]}}
```


[1]: https://github.com/alexanderkiel/phrase 