### PR TITLE
Fix/finding id min length check

### DIFF
--- a/src/wormbase/names/entity.clj
+++ b/src/wormbase/names/entity.clj
@@ -284,39 +284,58 @@
             (assoc :history prov)
             (ok))))))
 
+(defn finding-resticted?
+  [pattern & {:keys [min-chars-match
+                     id-pattern]
+              :or {min-chars-match 7
+                   id-pattern #"WB[a-zA-Z]+(\d+)"}}]
+  (when-let [[id numbers] (re-find id-pattern pattern)]
+    (if (< (count numbers) min-chars-match)
+      {:message (format
+                 "Identifier must contain at least %d digits (received %d)."
+                 min-chars-match
+                 (count numbers))})))
+
 ;; transducer for converting list of names to datalog variables.
 (def ->datalog-vars (map #(symbol (str "?" %))))
 
+(defn build-find-query
+  [entity-type find-attrs unqualified-attrs rule-head pattern]
+  (let [term (stc/conform ::wsc/find-term pattern)
+        pattern (re-pattern (str "^" term))
+        query-vars (sequence ->datalog-vars unqualified-attrs)
+        rule-clause (cons (symbol rule-head) '(?pattern ?name ?eid))
+        var->ident (zipmap query-vars find-attrs)
+        q-spec {:in '[$ % ?pattern]
+                :where
+                [rule-clause
+                 '[?eid ?id-ident ?id]]}
+        get-else-clauses (->> query-vars
+                              (map (fn [name-sym]
+                                     [(list 'get-else '$ '?eid (name-sym var->ident) "") name-sym]))
+                              (vec))]
+    (-> q-spec
+        (update :where (fn [clause]
+                         (concat clause get-else-clauses)))
+        (assoc :find query-vars :keys find-attrs))))
+
 (defn finder
-  [entity-type unqualfied-attrs]
+  [entity-type unqualified-attrs]
   (fn handle-find [request]
-    (when-let [pattern (some-> request :query-params :pattern str/trim)]
-      (let [db (:db request)
-            term (stc/conform ::wsc/find-term pattern)
-            pattern (re-pattern (str "^" term))
-            query-vars (sequence ->datalog-vars unqualfied-attrs)
-            find-attrs (map (partial keyword entity-type) unqualfied-attrs)
-            rule-head (str entity-type "-name")
-            matching-rules (wnm/make-rules rule-head find-attrs)
-            rule-clause (cons (symbol rule-head) '(?pattern ?name ?eid))
-            var->ident (zipmap query-vars find-attrs)
-            q-spec {:in '[$ % ?pattern]
-                    :where
-                    [rule-clause
-                     '[?eid ?id-ident ?id]]}
-            get-else-clauses (->> query-vars
-                                  (map (fn [name-sym]
-                                         [(list 'get-else '$ '?eid (name-sym var->ident) "") name-sym]))
-                                  (vec))
-            query (-> q-spec
-                      (update :where (fn [clause]
-                                       (concat clause get-else-clauses)))
-                      (assoc :find query-vars :keys find-attrs))
-            q-result (d/q query db matching-rules pattern)
-            res {:matches (if (seq q-result)
-                            (vec (map #(wnu/unqualify-keys % entity-type) q-result))
-                            [])}]
-        (ok res)))))
+    (when-let [s-pattern (some-> request :query-params :pattern str/trim)]
+      (if-let [restricted (finding-resticted? s-pattern)]
+        (ok restricted)
+        (let [db (:db request)
+              find-attrs (map (partial keyword entity-type) unqualified-attrs)
+              rule-head (str entity-type "-name")
+              matching-rules (wnm/make-rules rule-head find-attrs)
+              query (build-find-query entity-type find-attrs unqualified-attrs rule-head s-pattern)
+              regexp-pattern (re-pattern (str "^" s-pattern))
+              q-result (d/q query db matching-rules regexp-pattern)
+              res {:matches (if (seq q-result)
+                              (vec (map #(wnu/unqualify-keys % entity-type) q-result))
+                              [])}]
+          (ok res))))))
 
 (defn generic-attrs
   "Return the datomic attribute schema for a generic entity."

--- a/src/wormbase/names/matching.clj
+++ b/src/wormbase/names/matching.clj
@@ -1,8 +1,19 @@
 (ns wormbase.names.matching)
 
-(def name-matching-rules
+(def rules
   '[[(matches-name ?attr ?pattern ?name ?eid)
      [(re-seq ?pattern ?name)]
-     [?a :db/ident ?attr]
-     [?eid ?a ?name]]])
+     [?eid ?a ?name]
+     [?a :db/ident ?attr]]])
 
+(defn make-rules
+  "Make matching rules finding an entity by certain attributes.
+  Returns a quoted form."
+  [rule-name idents]
+  (->> idents
+       (map (fn [ident]
+              (conj
+               [(cons (symbol rule-name) '(?pattern ?name ?eid))]
+               (list 'matches-name ident '?pattern '?name '?eid))))
+       (concat rules)
+       (vec)))


### PR DESCRIPTION
Related to #298.
Perhaps merge both.

Provides  `message` key in HTTP 200 response body when number of characters in search term is <7 when matching regexp pattern: `^WB[a-zA-Z]+\d+` , otherwise executes the query with the search term.

Unifies the code for finding across all entity types. (previously gene and "generic" entity implementations were separate.)