### PR TITLE
Feature/iss 304 other names UI

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -48,7 +48,7 @@
       "pre-commit": "lint-staged"
     }
   },
-  "proxy": "http://lvh.me:4010",
+  "proxy": "https://test-names.wormbase.org",
   "browserslist": [
     ">0.2%",
     "not dead",

--- a/client/package.json
+++ b/client/package.json
@@ -48,7 +48,7 @@
       "pre-commit": "lint-staged"
     }
   },
-  "proxy": "https://test-names.wormbase.org",
+  "proxy": "http://lvh.me:4010",
   "browserslist": [
     ">0.2%",
     "not dead",

--- a/client/src/components/elements/AutocompleteSuggestion.js
+++ b/client/src/components/elements/AutocompleteSuggestion.js
@@ -31,7 +31,12 @@ function AutocompleteSuggestion({
         suggestion['sequence-name'] ||
         suggestion.name ||
         'Undefined'}{' '}
-      <span className={classes.wbId}>[{suggestion.id}]</span>
+      <span className={classes.wbId}>[{suggestion.id}]</span>{' '}
+      {suggestion['other-names'] ? (
+        <span>
+          <small>a.k.a.</small> {suggestion['other-names'].join(', ')}
+        </span>
+      ) : null}
     </MenuItem>
   );
 }

--- a/client/src/components/elements/BaseForm.js
+++ b/client/src/components/elements/BaseForm.js
@@ -237,7 +237,7 @@ class BaseForm extends Component {
         return (
           <WrappedComponent
             {...this.props}
-            id={fieldId}
+            //id={fieldId} // multiple input could have same id when field is an array
             disabled={disabled || this.props.disabled}
             value={this.state.value}
             error={Boolean(this.state.error)} //Boolean function not constructor

--- a/client/src/components/elements/BaseForm.js
+++ b/client/src/components/elements/BaseForm.js
@@ -114,7 +114,7 @@ class BaseForm extends Component {
 
   unpackFields = (props) => {
     function flatten(result, tree, prefix) {
-      if (typeof tree === 'object' && tree !== null) {
+      if (typeof tree === 'object' && tree !== null && !Array.isArray(tree)) {
         Object.keys(tree).reduce((result, keySegment) => {
           flatten(
             result,

--- a/client/src/components/elements/ListField.js
+++ b/client/src/components/elements/ListField.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import IconButton from '@material-ui/core/IconButton';
+import Tooltip from '@material-ui/core/Tooltip';
 import AddCircleOutlineIcon from '@material-ui/icons/AddCircleOutline';
 import DeleteIcon from '@material-ui/icons/Delete';
 import FormLabel from '@material-ui/core/FormLabel';
@@ -59,15 +60,17 @@ const ListField = ({
             onChange={(event) => handleValueChange(event, index)}
             value={v}
           />
-          <IconButton
-            aria-label="delete-name"
-            onClick={() => handleValueDelete(index)}
-          >
-            <DeleteIcon />
-          </IconButton>
+          <Tooltip title="Delete" placement="right">
+            <IconButton
+              aria-label="delete"
+              onClick={() => handleValueDelete(index)}
+            >
+              <DeleteIcon />
+            </IconButton>
+          </Tooltip>
         </div>
       ))}
-      <IconButton aria-label="add-name" onClick={handleAddValue}>
+      <IconButton onClick={handleAddValue}>
         <AddCircleOutlineIcon />
       </IconButton>
       {helperText ? <FormHelperText>{helperText}</FormHelperText> : null}

--- a/client/src/components/elements/ListField.js
+++ b/client/src/components/elements/ListField.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import IconButton from '@material-ui/core/IconButton';
+import AddCircleOutlineIcon from '@material-ui/icons/AddCircleOutline';
+import DeleteIcon from '@material-ui/icons/Delete';
+import TextField from './TextField';
+
+const ListField = ({ value: values = [''], onChange, ...TextFieldProps }) => {
+  const handleAddValue = (value) => {
+    if (onChange) {
+      onChange({
+        target: {
+          value: [...values, ''],
+        },
+      });
+    }
+  };
+
+  const handleValueChange = (event, index) => {
+    if (onChange) {
+      const newValues = [...values];
+      newValues[index] = event.target.value;
+      onChange({
+        target: {
+          value: newValues,
+        },
+      });
+    }
+  };
+
+  const handleValueDelete = (index) => {
+    if (onChange) {
+      const newValues = [...values.slice(0, index), ...values.slice(index + 1)];
+      console.log(newValues);
+      onChange({
+        target: {
+          value: newValues,
+        },
+      });
+    }
+  };
+
+  return (
+    <React.Fragment>
+      {values.map((v, index) => (
+        <div>
+          <TextField
+            variant="outlined"
+            {...TextFieldProps}
+            onChange={(event) => handleValueChange(event, index)}
+            value={v}
+          />
+          <IconButton
+            aria-label="delete-name"
+            onClick={() => handleValueDelete(index)}
+          >
+            <DeleteIcon />
+          </IconButton>
+        </div>
+      ))}
+      <IconButton aria-label="add-name" onClick={handleAddValue}>
+        <AddCircleOutlineIcon />
+      </IconButton>
+    </React.Fragment>
+  );
+};
+
+ListField.propTypes = {
+  value: PropTypes.array,
+  onChange: PropTypes.func,
+};
+
+export default ListField;

--- a/client/src/components/elements/ListField.js
+++ b/client/src/components/elements/ListField.js
@@ -58,6 +58,7 @@ const ListField = ({ value: values = [''], onChange, ...TextFieldProps }) => {
           </IconButton>
         </div>
       ))}
+
       <IconButton aria-label="add-name" onClick={handleAddValue}>
         <AddCircleOutlineIcon />
       </IconButton>

--- a/client/src/components/elements/ListField.js
+++ b/client/src/components/elements/ListField.js
@@ -3,9 +3,17 @@ import PropTypes from 'prop-types';
 import IconButton from '@material-ui/core/IconButton';
 import AddCircleOutlineIcon from '@material-ui/icons/AddCircleOutline';
 import DeleteIcon from '@material-ui/icons/Delete';
-import TextField from './TextField';
+import FormLabel from '@material-ui/core/FormLabel';
+import FormHelperText from '@material-ui/core/FormHelperText';
+import TextField from '@material-ui/core//TextField';
 
-const ListField = ({ value: values = [''], onChange, ...TextFieldProps }) => {
+const ListField = ({
+  value: values = [''],
+  label,
+  helperText,
+  onChange,
+  ...TextFieldProps
+}) => {
   const handleAddValue = (value) => {
     if (onChange) {
       onChange({
@@ -42,8 +50,9 @@ const ListField = ({ value: values = [''], onChange, ...TextFieldProps }) => {
 
   return (
     <React.Fragment>
+      <FormLabel component="legend">{label}</FormLabel>
       {values.map((v, index) => (
-        <div>
+        <div style={{ margin: '0.5em' }}>
           <TextField
             variant="outlined"
             {...TextFieldProps}
@@ -58,10 +67,10 @@ const ListField = ({ value: values = [''], onChange, ...TextFieldProps }) => {
           </IconButton>
         </div>
       ))}
-
       <IconButton aria-label="add-name" onClick={handleAddValue}>
         <AddCircleOutlineIcon />
       </IconButton>
+      {helperText ? <FormHelperText>{helperText}</FormHelperText> : null}
     </React.Fragment>
   );
 };

--- a/client/src/components/elements/index.js
+++ b/client/src/components/elements/index.js
@@ -62,6 +62,7 @@ export { default as TextField } from './TextField';
 export { default as Timestamp } from './Timestamp';
 export { default as Humanize } from './Humanize';
 export { default as ValidationError } from './ValidationError';
+export { default as ListField } from './ListField';
 
 export { default as useClipboard } from './useClipboard';
 

--- a/client/src/containers/Entity/EntityCreate.js
+++ b/client/src/containers/Entity/EntityCreate.js
@@ -27,10 +27,11 @@ class EntityCreate extends Component {
       entityType,
       apiPrefix = `/api/entity/${entityType}`,
       renderForm = this.renderForm,
+      data,
     } = this.props;
 
     return (
-      <EntityEditNew entityType={entityType} apiPrefix={apiPrefix}>
+      <EntityEditNew entityType={entityType} apiPrefix={apiPrefix} data={data}>
         {({ profileContext, formContext }) => {
           const {
             errorMessage = null,

--- a/client/src/containers/Entity/EntityEdit.js
+++ b/client/src/containers/Entity/EntityEdit.js
@@ -26,6 +26,7 @@ function EntityEdit({
     shortMessage: null,
     shortMessageVariant: 'info',
     dialog: null,
+    operationPayload: {},
   });
 
   function reducer(state, action = {}) {
@@ -36,11 +37,13 @@ function EntityEdit({
         return {
           ...state,
           dialog: payload.operation,
+          operationPayload: payload,
         };
       case 'DIALOG_CLOSE':
         return {
           ...state,
           dialog: null,
+          operationPayload: {},
         };
       case 'DIALOG_OPERATION_SUCCESS':
         return {
@@ -316,9 +319,13 @@ function EntityEdit({
                 entityType: entityType,
                 withFieldData,
               },
-              getOperationProps: (operation) => ({
+              getOperationProps: (operation, payload = {}) => ({
                 onClick: () => {
-                  dispatch({ type: 'DIALOG_OPEN', payload: { operation } });
+                  console.log(`operation: ${operation}`);
+                  dispatch({
+                    type: 'DIALOG_OPEN',
+                    payload: { operation, ...payload },
+                  });
                 },
               }),
               getDialogProps: (operation) => ({
@@ -328,6 +335,7 @@ function EntityEdit({
                 name: renderDisplayName(data),
                 data: data,
                 open: state.dialog === operation,
+                operationPayload: state.operationPayload,
                 onClose: () => dispatch({ type: 'DIALOG_CLOSE' }),
                 onSubmitSuccess: ({ created = {}, updated = {} }) => {
                   dispatch({

--- a/client/src/containers/Entity/EntityHistory.js
+++ b/client/src/containers/Entity/EntityHistory.js
@@ -22,9 +22,15 @@ class EntityHistory extends Component {
     }
 
     const changeLookup = changes.reduce((result, changeEntry) => {
+      const { added: previousAdded = [], retracted: previousRetracted = [] } =
+        result[changeEntry.attr] || {};
       const changeSumamry = {
-        ...result[changeEntry.attr],
-        [changeEntry.added ? 'added' : 'retracted']: changeEntry.value,
+        added: changeEntry.added
+          ? [...previousAdded, changeEntry.value]
+          : previousAdded,
+        retracted: changeEntry.added
+          ? previousRetracted
+          : [...previousRetracted, changeEntry.value],
       };
       return {
         ...result,
@@ -51,10 +57,10 @@ class EntityHistory extends Component {
                   {attr}
                 </TableCell>
                 <TableCell className={this.props.classes.changeTableCell}>
-                  {changeLookup[attr].retracted || '-'}
+                  {changeLookup[attr].retracted.join(', ') || '-'}
                 </TableCell>
                 <TableCell className={this.props.classes.changeTableCell}>
-                  <strong>{changeLookup[attr].added || '-'}</strong>
+                  <strong>{changeLookup[attr].added.join(', ') || '-'}</strong>
                 </TableCell>
               </TableRow>
             );

--- a/client/src/containers/Entity/EntityProfile.js
+++ b/client/src/containers/Entity/EntityProfile.js
@@ -175,7 +175,11 @@ class EntityProfile extends Component {
                       {renderStatus(renderProps)}
                       {renderForm ? (
                         <ErrorBoundary>
-                          {renderForm({ ...renderProps, ...formContext })}
+                          {renderForm({
+                            ...renderProps,
+                            ...formContext,
+                            getOperationProps,
+                          })}
                           {dirtinessContext(({ dirty }) =>
                             dirty ? (
                               <ReasonField

--- a/client/src/containers/Gene/DialogGeneAddOtherName.js
+++ b/client/src/containers/Gene/DialogGeneAddOtherName.js
@@ -55,7 +55,7 @@ class DialogGeneAddOtherName extends Component {
           <ProgressButton {...props}>Add name</ProgressButton>
         )}
         data={{
-          'other-names': ['zzz'],
+          'other-names': [''],
         }}
         {...otherProps}
       >

--- a/client/src/containers/Gene/DialogGeneAddOtherName.js
+++ b/client/src/containers/Gene/DialogGeneAddOtherName.js
@@ -52,7 +52,7 @@ class DialogGeneAddOtherName extends Component {
         title={`Add alternative names to ${entityType} ${name}`}
         submitter={this.submitData}
         renderSubmitButton={(props) => (
-          <ProgressButton {...props}>Add name</ProgressButton>
+          <ProgressButton {...props}>Add name(s)</ProgressButton>
         )}
         data={{
           'other-names': [''],
@@ -74,7 +74,8 @@ class DialogGeneAddOtherName extends Component {
               <DialogContentText>
                 <ValidationError {...errorMessage} />
               </DialogContentText>
-              <OtherNamesField label="Alternative name" />
+              <br />
+              <OtherNamesField label="Alternative name(s)" />
               <ReasonField
                 label="Reason"
                 helperText={`Enter the reason for the alternative name`}

--- a/client/src/containers/Gene/DialogGeneAddOtherName.js
+++ b/client/src/containers/Gene/DialogGeneAddOtherName.js
@@ -1,0 +1,105 @@
+import React, { Component } from 'react';
+import { mockFetchOrNot } from '../../mock';
+import { capitalize } from '../../utils/format';
+import PropTypes from 'prop-types';
+import {
+  withStyles,
+  AjaxDialog,
+  DialogContent,
+  DialogContentText,
+  ProgressButton,
+  TextArea,
+  TextField,
+  ListField,
+  ValidationError,
+} from '../../components/elements';
+import { createOpenOnlyTypeChecker } from '../../utils/types';
+
+class DialogGeneAddOtherName extends Component {
+  submitData = (data, authorizedFetch) => {
+    return mockFetchOrNot(
+      (mockFetch) => {
+        return mockFetch.post('*', {
+          updated: {
+            id: this.props.wbId,
+          },
+        });
+      },
+      () => {
+        return authorizedFetch(
+          `${this.props.apiPrefix}/${this.props.wbId}/update-other-names`,
+          {
+            method: 'PUT',
+            body: JSON.stringify({
+              ...data,
+            }),
+          }
+        );
+      }
+    );
+  };
+
+  render() {
+    const {
+      wbId,
+      name,
+      entityType,
+      data: entityData,
+      ...otherProps
+    } = this.props;
+    return (
+      <AjaxDialog
+        title={`Add alternative names to ${entityType} ${name}`}
+        submitter={this.submitData}
+        renderSubmitButton={(props) => (
+          <ProgressButton {...props}>Add name</ProgressButton>
+        )}
+        data={{
+          'other-names': ['zzz'],
+        }}
+        {...otherProps}
+      >
+        {({ withFieldData, errorMessage }) => {
+          const ReasonField = withFieldData(TextArea, 'why');
+          const OtherNamesField = withFieldData(ListField, 'other-names');
+          return (
+            <DialogContent>
+              <DialogContentText>
+                Please enter the alternative name to be associated with{' '}
+                {capitalize(entityType)}{' '}
+                <strong>
+                  {name} ({wbId})
+                </strong>
+              </DialogContentText>
+              <DialogContentText>
+                <ValidationError {...errorMessage} />
+              </DialogContentText>
+              <OtherNamesField label="Alternative name" />
+              <ReasonField
+                label="Reason"
+                helperText={`Enter the reason for the alternative name`}
+                fullWidth
+              />
+            </DialogContent>
+          );
+        }}
+      </AjaxDialog>
+    );
+  }
+}
+
+DialogGeneAddOtherName.propTypes = {
+  name: createOpenOnlyTypeChecker(PropTypes.string.isRequired),
+  wbId: createOpenOnlyTypeChecker(PropTypes.string.isRequired),
+  entityType: createOpenOnlyTypeChecker(PropTypes.string.isRequired),
+  apiPrefix: PropTypes.string.isRequired,
+};
+
+const styles = (theme) => ({
+  submitButton: {
+    color: theme.palette.error.main,
+    textTransform: 'inherit',
+  },
+});
+
+export default withStyles(styles)(DialogGeneAddOtherName);

--- a/client/src/containers/Gene/DialogGeneAddOtherName.js
+++ b/client/src/containers/Gene/DialogGeneAddOtherName.js
@@ -66,7 +66,7 @@ class DialogGeneAddOtherName extends Component {
             <DialogContent>
               <DialogContentText>
                 Please enter the alternative name to be associated with{' '}
-                {capitalize(entityType)} <strong>{name}</strong>({wbId})
+                {capitalize(entityType)} <strong>{name}</strong> ({wbId})
               </DialogContentText>
               <DialogContentText>
                 <ValidationError {...errorMessage} />

--- a/client/src/containers/Gene/DialogGeneAddOtherName.js
+++ b/client/src/containers/Gene/DialogGeneAddOtherName.js
@@ -66,10 +66,7 @@ class DialogGeneAddOtherName extends Component {
             <DialogContent>
               <DialogContentText>
                 Please enter the alternative name to be associated with{' '}
-                {capitalize(entityType)}{' '}
-                <strong>
-                  {name} ({wbId})
-                </strong>
+                {capitalize(entityType)} <strong>{name}</strong>({wbId})
               </DialogContentText>
               <DialogContentText>
                 <ValidationError {...errorMessage} />

--- a/client/src/containers/Gene/DialogGeneDeleteOtherName.js
+++ b/client/src/containers/Gene/DialogGeneDeleteOtherName.js
@@ -1,0 +1,109 @@
+import React, { Component } from 'react';
+import { mockFetchOrNot } from '../../mock';
+import { capitalize } from '../../utils/format';
+import PropTypes from 'prop-types';
+import {
+  withStyles,
+  AjaxDialog,
+  DialogContent,
+  DialogContentText,
+  ProgressButton,
+  TextArea,
+  TextField,
+  ListField,
+  ValidationError,
+} from '../../components/elements';
+import { createOpenOnlyTypeChecker } from '../../utils/types';
+
+class DialogGeneDeleteOtherName extends Component {
+  submitData = (data, authorizedFetch) => {
+    return mockFetchOrNot(
+      (mockFetch) => {
+        return mockFetch.delete('*', {
+          updated: {
+            id: this.props.wbId,
+          },
+        });
+      },
+      () => {
+        return authorizedFetch(
+          `${this.props.apiPrefix}/${this.props.wbId}/update-other-names`,
+          {
+            method: 'DELETE',
+            body: JSON.stringify({
+              ...data,
+            }),
+          }
+        );
+      }
+    );
+  };
+
+  render() {
+    const {
+      wbId,
+      name,
+      entityType,
+      data: entityData,
+      operationPayload,
+      ...otherProps
+    } = this.props;
+    return (
+      <AjaxDialog
+        title={`Delete alternative name ${operationPayload.otherName}`}
+        data={{
+          'other-names': [operationPayload.otherName],
+        }}
+        submitter={this.submitData}
+        renderSubmitButton={(props) => (
+          <ProgressButton {...props}>Delete name</ProgressButton>
+        )}
+        {...otherProps}
+      >
+        {({ withFieldData, errorMessage }) => {
+          const ReasonField = withFieldData(TextArea, 'why');
+          return (
+            <DialogContent>
+              <DialogContentText>
+                Alternative name <strong>{operationPayload.otherName}</strong>{' '}
+                will be deleted from {capitalize(entityType)}{' '}
+                <strong>
+                  {name} ({wbId})
+                </strong>
+                . Are you sure?
+              </DialogContentText>
+              <DialogContentText>
+                <ValidationError {...errorMessage} />
+              </DialogContentText>
+
+              <ReasonField
+                label="Reason"
+                helperText={`Enter the reason for deleting the alternative name`}
+                fullWidth
+              />
+            </DialogContent>
+          );
+        }}
+      </AjaxDialog>
+    );
+  }
+}
+
+DialogGeneDeleteOtherName.propTypes = {
+  name: createOpenOnlyTypeChecker(PropTypes.string.isRequired),
+  wbId: createOpenOnlyTypeChecker(PropTypes.string.isRequired),
+  entityType: createOpenOnlyTypeChecker(PropTypes.string.isRequired),
+  apiPrefix: PropTypes.string.isRequired,
+  operationPayload: PropTypes.shape({
+    otherName: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+const styles = (theme) => ({
+  submitButton: {
+    color: theme.palette.error.main,
+    textTransform: 'inherit',
+  },
+});
+
+export default withStyles(styles)(DialogGeneDeleteOtherName);

--- a/client/src/containers/Gene/GeneCreate.js
+++ b/client/src/containers/Gene/GeneCreate.js
@@ -10,6 +10,9 @@ class GeneCreate extends Component {
       <EntityCreate
         {...others}
         apiPrefix="/api/gene"
+        data={{
+          'other-names': [],
+        }}
         renderForm={(props) => <GeneForm {...props} />}
       />
     );

--- a/client/src/containers/Gene/GeneForm.js
+++ b/client/src/containers/Gene/GeneForm.js
@@ -8,7 +8,12 @@ import {
 
 class GeneForm extends Component {
   render() {
-    const { withFieldData, cloned = false } = this.props;
+    const {
+      withFieldData,
+      cloned = false,
+      isEdit = false,
+      addNamesOtherButton,
+    } = this.props;
     const CgcNameField = withFieldData(TextField, 'cgc-name');
     const SequenceNameField = withFieldData(TextField, 'sequence-name');
     const SpeciesSelectField = withFieldData(SpeciesSelect, 'species');
@@ -31,6 +36,8 @@ class GeneForm extends Component {
             "For cloned genes, biotype is required. Otherwise, it's optional"
           }
         />
+        <br />
+        {addNamesOtherButton}
       </React.Fragment>
     );
   }
@@ -39,6 +46,7 @@ class GeneForm extends Component {
 GeneForm.propTypes = {
   withFieldData: PropTypes.func.isRequired,
   cloned: PropTypes.bool,
+  isEdit: PropTypes.bool,
 };
 
 export default GeneForm;

--- a/client/src/containers/Gene/GeneForm.js
+++ b/client/src/containers/Gene/GeneForm.js
@@ -13,7 +13,7 @@ class GeneForm extends Component {
       withFieldData,
       cloned = false,
       isEdit = false,
-      addNamesOtherButton,
+      otherNamesEdit,
     } = this.props;
     const CgcNameField = withFieldData(TextField, 'cgc-name');
     const SequenceNameField = withFieldData(TextField, 'sequence-name');
@@ -39,8 +39,9 @@ class GeneForm extends Component {
           }
         />
         <br />
+        <br />
         {isEdit ? (
-          addNamesOtherButton
+          otherNamesEdit
         ) : (
           <OtherNamesField label="Alternative name(s)" />
         )}

--- a/client/src/containers/Gene/GeneForm.js
+++ b/client/src/containers/Gene/GeneForm.js
@@ -4,6 +4,7 @@ import {
   BiotypeSelect,
   TextField,
   SpeciesSelect,
+  ListField,
 } from '../../components/elements';
 
 class GeneForm extends Component {
@@ -18,6 +19,7 @@ class GeneForm extends Component {
     const SequenceNameField = withFieldData(TextField, 'sequence-name');
     const SpeciesSelectField = withFieldData(SpeciesSelect, 'species');
     const BiotypeSelectField = withFieldData(BiotypeSelect, 'biotype');
+    const OtherNamesField = withFieldData(ListField, 'other-names');
 
     return (
       <React.Fragment>
@@ -37,7 +39,11 @@ class GeneForm extends Component {
           }
         />
         <br />
-        {addNamesOtherButton}
+        {isEdit ? (
+          addNamesOtherButton
+        ) : (
+          <OtherNamesField label="Alternative name" />
+        )}
       </React.Fragment>
     );
   }

--- a/client/src/containers/Gene/GeneForm.js
+++ b/client/src/containers/Gene/GeneForm.js
@@ -42,7 +42,7 @@ class GeneForm extends Component {
         {isEdit ? (
           addNamesOtherButton
         ) : (
-          <OtherNamesField label="Alternative name" />
+          <OtherNamesField label="Alternative name(s)" />
         )}
       </React.Fragment>
     );

--- a/client/src/containers/Gene/GeneProfile.js
+++ b/client/src/containers/Gene/GeneProfile.js
@@ -13,12 +13,14 @@ import GeneForm from './GeneForm';
 import SuppressGeneDialog from './SuppressGeneDialog';
 import MergeGeneDialog from './MergeGeneDialog';
 import SplitGeneDialog from './SplitGeneDialog';
+import DialogGeneAddOtherName from './DialogGeneAddOtherName';
 
 const OPERATION_KILL = 'kill';
 const OPERATION_RESURRECT = 'resurrect';
 const OPERATION_SUPPRESS = 'suppress';
 const OPERATION_MERGE = 'merge';
 const OPERATION_SPLIT = 'split';
+const OPERATION_ADD_NAMES_OTHER = 'add_names_other';
 
 class GeneProfile extends Component {
   getDisplayName = (data = {}) =>
@@ -129,13 +131,26 @@ class GeneProfile extends Component {
               <SuppressGeneDialog {...getDialogProps(OPERATION_SUPPRESS)} />
               <MergeGeneDialog {...getDialogProps(OPERATION_MERGE)} />
               <SplitGeneDialog {...getDialogProps(OPERATION_SPLIT)} />
+              <DialogGeneAddOtherName
+                {...getDialogProps(OPERATION_ADD_NAMES_OTHER)}
+              />
             </React.Fragment>
           );
         }}
-        renderForm={({ data, changes, ...props }) => (
+        renderForm={({ data, changes, getOperationProps, ...props }) => (
           <GeneForm
             {...props}
             cloned={Boolean(data['sequence-name'] || data['biotype'])}
+            isEdit
+            addNamesOtherButton={
+              <Button
+                {...getOperationProps(OPERATION_ADD_NAMES_OTHER)}
+                variant="raised"
+                size="small"
+              >
+                Add alternative names
+              </Button>
+            }
           />
         )}
         renderOperationTip={({ data, Wrapper }) =>

--- a/client/src/containers/Gene/GeneProfile.js
+++ b/client/src/containers/Gene/GeneProfile.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
+import FormLabel from '@material-ui/core/FormLabel';
+import IconButton from '@material-ui/core/IconButton';
 import { Button, Humanize, Typography } from '../../components/elements';
 import {
   EntityProfile,
@@ -14,6 +16,8 @@ import SuppressGeneDialog from './SuppressGeneDialog';
 import MergeGeneDialog from './MergeGeneDialog';
 import SplitGeneDialog from './SplitGeneDialog';
 import DialogGeneAddOtherName from './DialogGeneAddOtherName';
+import DialogGeneDeleteOtherName from './DialogGeneDeleteOtherName';
+import DeleteIcon from '@material-ui/icons/Delete';
 
 const OPERATION_KILL = 'kill';
 const OPERATION_RESURRECT = 'resurrect';
@@ -21,6 +25,7 @@ const OPERATION_SUPPRESS = 'suppress';
 const OPERATION_MERGE = 'merge';
 const OPERATION_SPLIT = 'split';
 const OPERATION_ADD_NAMES_OTHER = 'add_names_other';
+const OPERATION_DELETE_NAME_OTHER = 'delete_names_other';
 
 class GeneProfile extends Component {
   getDisplayName = (data = {}) =>
@@ -134,6 +139,9 @@ class GeneProfile extends Component {
               <DialogGeneAddOtherName
                 {...getDialogProps(OPERATION_ADD_NAMES_OTHER)}
               />
+              <DialogGeneDeleteOtherName
+                {...getDialogProps(OPERATION_DELETE_NAME_OTHER)}
+              />
             </React.Fragment>
           );
         }}
@@ -143,13 +151,27 @@ class GeneProfile extends Component {
             cloned={Boolean(data['sequence-name'] || data['biotype'])}
             isEdit
             addNamesOtherButton={
-              <Button
-                {...getOperationProps(OPERATION_ADD_NAMES_OTHER)}
-                variant="raised"
-                size="small"
-              >
-                Add alternative names
-              </Button>
+              <React.Fragment>
+                {(data['other-names'] || []).map((otherName) => (
+                  <div>
+                    <span>{otherName} </span>
+                    <IconButton
+                      {...getOperationProps(OPERATION_DELETE_NAME_OTHER, {
+                        otherName,
+                      })}
+                    >
+                      <DeleteIcon />
+                    </IconButton>
+                  </div>
+                ))}
+                <Button
+                  {...getOperationProps(OPERATION_ADD_NAMES_OTHER)}
+                  variant="raised"
+                  size="small"
+                >
+                  Add alternative names
+                </Button>
+              </React.Fragment>
             }
           />
         )}

--- a/client/src/containers/Gene/GeneProfile.js
+++ b/client/src/containers/Gene/GeneProfile.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import FormLabel from '@material-ui/core/FormLabel';
 import IconButton from '@material-ui/core/IconButton';
+import Tooltip from '@material-ui/core/Tooltip';
 import { Button, Humanize, Typography } from '../../components/elements';
 import {
   EntityProfile,
@@ -157,13 +158,15 @@ class GeneProfile extends Component {
                   {(data['other-names'] || []).map((otherName) => (
                     <div>
                       <span>{otherName} </span>
-                      <IconButton
-                        {...getOperationProps(OPERATION_DELETE_NAME_OTHER, {
-                          otherName,
-                        })}
-                      >
-                        <DeleteIcon />
-                      </IconButton>
+                      <Tooltip title="Delete name" placement="right">
+                        <IconButton
+                          {...getOperationProps(OPERATION_DELETE_NAME_OTHER, {
+                            otherName,
+                          })}
+                        >
+                          <DeleteIcon />
+                        </IconButton>
+                      </Tooltip>
                     </div>
                   ))}
                   <Button

--- a/client/src/containers/Gene/GeneProfile.js
+++ b/client/src/containers/Gene/GeneProfile.js
@@ -150,28 +150,31 @@ class GeneProfile extends Component {
             {...props}
             cloned={Boolean(data['sequence-name'] || data['biotype'])}
             isEdit
-            addNamesOtherButton={
-              <React.Fragment>
-                {(data['other-names'] || []).map((otherName) => (
-                  <div>
-                    <span>{otherName} </span>
-                    <IconButton
-                      {...getOperationProps(OPERATION_DELETE_NAME_OTHER, {
-                        otherName,
-                      })}
-                    >
-                      <DeleteIcon />
-                    </IconButton>
-                  </div>
-                ))}
-                <Button
-                  {...getOperationProps(OPERATION_ADD_NAMES_OTHER)}
-                  variant="raised"
-                  size="small"
-                >
-                  Add alternative names
-                </Button>
-              </React.Fragment>
+            otherNamesEdit={
+              <div>
+                <FormLabel component="legend">Alternative names(s)</FormLabel>
+                <div style={{ margin: '0 0.5em' }}>
+                  {(data['other-names'] || []).map((otherName) => (
+                    <div>
+                      <span>{otherName} </span>
+                      <IconButton
+                        {...getOperationProps(OPERATION_DELETE_NAME_OTHER, {
+                          otherName,
+                        })}
+                      >
+                        <DeleteIcon />
+                      </IconButton>
+                    </div>
+                  ))}
+                  <Button
+                    {...getOperationProps(OPERATION_ADD_NAMES_OTHER)}
+                    variant="raised"
+                    size="small"
+                  >
+                    Add alternative names
+                  </Button>
+                </div>
+              </div>
             }
           />
         )}

--- a/client/src/containers/Gene/SplitGeneDialog.js
+++ b/client/src/containers/Gene/SplitGeneDialog.js
@@ -10,6 +10,7 @@ import {
   ProgressButton,
   TextArea,
   TextField,
+  ListField,
   ValidationError,
 } from '../../components/elements';
 import { createOpenOnlyTypeChecker } from '../../utils/types';
@@ -79,6 +80,7 @@ class SplitGeneDialog extends Component {
         data={{
           ...data,
           'product:biotype': data.biotype,
+          'product:other-names': [],
         }}
       >
         {({ withFieldData, errorMessage }) => {
@@ -94,6 +96,10 @@ class SplitGeneDialog extends Component {
           const BiotypeSelectField = withFieldData(
             BiotypeSelect,
             'product:biotype'
+          );
+          const OtherNamesField = withFieldData(
+            ListField,
+            'product:other-names'
           );
           return (
             <DialogContent>
@@ -117,6 +123,7 @@ class SplitGeneDialog extends Component {
               </DialogContentText>
               <SequenceNameField label="Sequence name" />
               <BiotypeSelectField required />
+              <OtherNamesField label="Alternative name(s)" />
               <ReasonField
                 label="Reason"
                 helperText="Enter the reason for splitting the gene"


### PR DESCRIPTION
UI changes related to other names of Genes #304
- add other names when creating a gene
- add other names to existing gene
- delete other names of existing gene
- autocomplete suggestion to include other-names if available
- recent activities and gene history to handle multi-value other-names
- other-names for split gene product

The PR assumes request body to have the format of:
```
{
  data: {
    other-names: [ name1 , name2 ... ]
  },
  prov: {
    ...
  }
}
```